### PR TITLE
refactor: rename project from StreamyCarrot to RabbitStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StreamyCarrot
+# RabbitStream
 
 A PHP library implementing the [RabbitMQ Streams Protocol](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_stream/docs/PROTOCOL.adoc) client.
 
@@ -12,21 +12,21 @@ It provides low-level TCP communication with a RabbitMQ broker over the native S
 ## Installation
 
 ```bash
-composer require crazy-goat/streamy-carrot
+composer require crazy-goat/rabbit-stream
 ```
 
 ## Usage
 
 ```php
-use CrazyGoat\StreamyCarrot\StreamConnection;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneResponseV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
 
 $connection = new StreamConnection('127.0.0.1', 5552);
 $connection->connect();

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "crazy-goat/streamy-carrot",
+    "name": "crazy-goat/rabbit-stream",
     "type": "library",
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "CrazyGoat\\StreamyCarrot\\": "src/"
+            "CrazyGoat\\RabbitStream\\": "src/"
         }
     },
     "authors": [
@@ -15,7 +15,7 @@
     ],
     "autoload-dev": {
         "psr-4": {
-            "CrazyGoat\\StreamyCarrot\\Tests\\": "tests/"
+            "CrazyGoat\\RabbitStream\\Tests\\": "tests/"
         }
     },
     "require-dev": {

--- a/examples/simple_publisher.php
+++ b/examples/simple_publisher.php
@@ -1,13 +1,13 @@
 <?php
 
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\OpenResponseV1;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\StreamConnection;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
 
 include __DIR__ . '/../vendor/autoload.php';
 

--- a/src/Buffer/FromStreamBufferInterface.php
+++ b/src/Buffer/FromStreamBufferInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Buffer;
+namespace CrazyGoat\RabbitStream\Buffer;
 
 interface FromStreamBufferInterface
 {

--- a/src/Buffer/ReadBuffer.php
+++ b/src/Buffer/ReadBuffer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Buffer;
+namespace CrazyGoat\RabbitStream\Buffer;
 
 class ReadBuffer
 {

--- a/src/Buffer/ToStreamBufferInterface.php
+++ b/src/Buffer/ToStreamBufferInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Buffer;
+namespace CrazyGoat\RabbitStream\Buffer;
 
 interface ToStreamBufferInterface
 {

--- a/src/Buffer/WriteBuffer.php
+++ b/src/Buffer/WriteBuffer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Buffer;
+namespace CrazyGoat\RabbitStream\Buffer;
 
 class WriteBuffer
 {

--- a/src/Enum/KeyEnum.php
+++ b/src/Enum/KeyEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Enum;
+namespace CrazyGoat\RabbitStream\Enum;
 
 enum KeyEnum: int
 {

--- a/src/Enum/ResponseCodeEnum.php
+++ b/src/Enum/ResponseCodeEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Enum;
+namespace CrazyGoat\RabbitStream\Enum;
 
 enum ResponseCodeEnum: int
 {

--- a/src/Request/ConsumerUpdateReplyV1.php
+++ b/src/Request/ConsumerUpdateReplyV1.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class ConsumerUpdateReplyV1 implements ToStreamBufferInterface, KeyVersionInterface
 {

--- a/src/Request/DeclarePublisherRequestV1.php
+++ b/src/Request/DeclarePublisherRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class DeclarePublisherRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
 {

--- a/src/Request/DeletePublisherRequestV1.php
+++ b/src/Request/DeletePublisherRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class DeletePublisherRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
 {

--- a/src/Request/HeartbeatRequestV1.php
+++ b/src/Request/HeartbeatRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class HeartbeatRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, KeyVersionInterface
 {

--- a/src/Request/OpenRequest.php
+++ b/src/Request/OpenRequest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class OpenRequest implements KeyVersionInterface, ToStreamBufferInterface, CorrelationInterface
 {

--- a/src/Request/PeerPropertiesToStreamBufferV1.php
+++ b/src/Request/PeerPropertiesToStreamBufferV1.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\KeyValue;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\KeyValue;
 
 class PeerPropertiesToStreamBufferV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
 {

--- a/src/Request/PublishRequestV1.php
+++ b/src/Request/PublishRequestV1.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\PublishedMessage;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\PublishedMessage;
 
 class PublishRequestV1 implements ToStreamBufferInterface, KeyVersionInterface
 {

--- a/src/Request/PublishRequestV2.php
+++ b/src/Request/PublishRequestV2.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\PublishedMessageV2;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\PublishedMessageV2;
 
 class PublishRequestV2 implements ToStreamBufferInterface, KeyVersionInterface
 {

--- a/src/Request/SaslAuthenticateRequestV1.php
+++ b/src/Request/SaslAuthenticateRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class SaslAuthenticateRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
 {

--- a/src/Request/SaslHandshakeRequestV1.php
+++ b/src/Request/SaslHandshakeRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class SaslHandshakeRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
 {

--- a/src/Request/TuneRequestV1.php
+++ b/src/Request/TuneRequestV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Request;
+namespace CrazyGoat\RabbitStream\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, KeyVersionInterface
 {

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class ConsumerUpdateQueryV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class DeclarePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class DeletePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
 {

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
 {

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\KeyValue;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\KeyValue;
 
 class OpenResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\KeyValue;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\KeyValue;
 
 class PeerPropertiesResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
 {

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
-use CrazyGoat\StreamyCarrot\VO\PublishingError;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\PublishingError;
 
 class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
 {

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class SaslAuthenticateResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\CommandTrait;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationTrait;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
-use CrazyGoat\StreamyCarrot\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
 
 class SaslHandshakeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
 {

--- a/src/Response/TuneResponseV1.php
+++ b/src/Response/TuneResponseV1.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Response;
+namespace CrazyGoat\RabbitStream\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 
 class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface
 {

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot;
+namespace CrazyGoat\RabbitStream;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Request\HeartbeatRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\ConsumerUpdateQueryV1;
-use CrazyGoat\StreamyCarrot\Response\DeclarePublisherResponseV1;
-use CrazyGoat\StreamyCarrot\Response\DeletePublisherResponseV1;
-use CrazyGoat\StreamyCarrot\Response\DeliverResponseV1;
-use CrazyGoat\StreamyCarrot\Response\MetadataUpdateResponseV1;
-use CrazyGoat\StreamyCarrot\Response\OpenResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PeerPropertiesResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PublishConfirmResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PublishErrorResponseV1;
-use CrazyGoat\StreamyCarrot\Response\SaslAuthenticateResponseV1;
-use CrazyGoat\StreamyCarrot\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Request\HeartbeatRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\ConsumerUpdateQueryV1;
+use CrazyGoat\RabbitStream\Response\DeclarePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\DeletePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\DeliverResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataUpdateResponseV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishConfirmResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishErrorResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 
 class ResponseBuilder
 {

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot;
+namespace CrazyGoat\RabbitStream;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\KeyEnum;
-use CrazyGoat\StreamyCarrot\Request\ConsumerUpdateReplyV1;
-use CrazyGoat\StreamyCarrot\Request\HeartbeatRequestV1;
-use CrazyGoat\StreamyCarrot\Response\ConsumerUpdateQueryV1;
-use CrazyGoat\StreamyCarrot\Response\DeliverResponseV1;
-use CrazyGoat\StreamyCarrot\Response\MetadataUpdateResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PublishConfirmResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PublishErrorResponseV1;
-use CrazyGoat\StreamyCarrot\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Request\ConsumerUpdateReplyV1;
+use CrazyGoat\RabbitStream\Request\HeartbeatRequestV1;
+use CrazyGoat\RabbitStream\Response\ConsumerUpdateQueryV1;
+use CrazyGoat\RabbitStream\Response\DeliverResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataUpdateResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishConfirmResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishErrorResponseV1;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
 
 class StreamConnection
 {

--- a/src/Trait/CommandTrait.php
+++ b/src/Trait/CommandTrait.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Trait;
+namespace CrazyGoat\RabbitStream\Trait;
 
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
-use CrazyGoat\StreamyCarrot\Enum\ResponseCodeEnum;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\ResponseCodeEnum;
 
 trait CommandTrait
 {

--- a/src/Trait/CorrelationInterface.php
+++ b/src/Trait/CorrelationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Trait;
+namespace CrazyGoat\RabbitStream\Trait;
 
 interface CorrelationInterface
 {

--- a/src/Trait/CorrelationTrait.php
+++ b/src/Trait/CorrelationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Trait;
+namespace CrazyGoat\RabbitStream\Trait;
 
 trait CorrelationTrait
 {

--- a/src/Trait/KeyVersionInterface.php
+++ b/src/Trait/KeyVersionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Trait;
+namespace CrazyGoat\RabbitStream\Trait;
 
 interface KeyVersionInterface
 {

--- a/src/Trait/V1Trait.php
+++ b/src/Trait/V1Trait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Trait;
+namespace CrazyGoat\RabbitStream\Trait;
 
 trait V1Trait
 {

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\VO;
+namespace CrazyGoat\RabbitStream\VO;
 
 
-use CrazyGoat\StreamyCarrot\Buffer\FromStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
 class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface
 {

--- a/src/VO/PublishedMessage.php
+++ b/src/VO/PublishedMessage.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\VO;
+namespace CrazyGoat\RabbitStream\VO;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
 class PublishedMessage implements ToStreamBufferInterface
 {

--- a/src/VO/PublishedMessageV2.php
+++ b/src/VO/PublishedMessageV2.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\VO;
+namespace CrazyGoat\RabbitStream\VO;
 
-use CrazyGoat\StreamyCarrot\Buffer\ToStreamBufferInterface;
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
 class PublishedMessageV2 implements ToStreamBufferInterface
 {

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\VO;
+namespace CrazyGoat\RabbitStream\VO;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 
 class PublishingError
 {

--- a/tests/Buffer/ReadBufferTest.php
+++ b/tests/Buffer/ReadBufferTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Buffer;
+namespace CrazyGoat\RabbitStream\Tests\Buffer;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use PHPUnit\Framework\TestCase;
 
 class ReadBufferTest extends TestCase

--- a/tests/Buffer/WriteBufferTest.php
+++ b/tests/Buffer/WriteBufferTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Buffer;
+namespace CrazyGoat\RabbitStream\Tests\Buffer;
 
-use CrazyGoat\StreamyCarrot\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use PHPUnit\Framework\TestCase;
 
 class WriteBufferTest extends TestCase

--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\E2E;
+namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\OpenResponseV1;
-use CrazyGoat\StreamyCarrot\Response\PeerPropertiesResponseV1;
-use CrazyGoat\StreamyCarrot\Response\SaslAuthenticateResponseV1;
-use CrazyGoat\StreamyCarrot\Response\SaslHandshakeResponseV1;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\StreamConnection;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
 use PHPUnit\Framework\TestCase;
 
 class ConnectionHandshakeTest extends TestCase

--- a/tests/E2E/DeclarePublisherTest.php
+++ b/tests/E2E/DeclarePublisherTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\E2E;
+namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\StreamyCarrot\Request\DeclarePublisherRequestV1;
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\DeclarePublisherResponseV1;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\StreamConnection;
+use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\DeclarePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
 use PHPUnit\Framework\TestCase;
 
 class DeclarePublisherTest extends TestCase

--- a/tests/E2E/DeletePublisherTest.php
+++ b/tests/E2E/DeletePublisherTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\E2E;
+namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\StreamyCarrot\Request\DeclarePublisherRequestV1;
-use CrazyGoat\StreamyCarrot\Request\DeletePublisherRequestV1;
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\DeletePublisherResponseV1;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\StreamConnection;
+use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeletePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\DeletePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
 use PHPUnit\Framework\TestCase;
 
 class DeletePublisherTest extends TestCase

--- a/tests/E2E/PublishTest.php
+++ b/tests/E2E/PublishTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\E2E;
+namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\StreamyCarrot\Request\DeclarePublisherRequestV1;
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\Request\PublishRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
-use CrazyGoat\StreamyCarrot\StreamConnection;
-use CrazyGoat\StreamyCarrot\VO\PublishedMessage;
+use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\PublishRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use CrazyGoat\RabbitStream\VO\PublishedMessage;
 use PHPUnit\Framework\TestCase;
 
 class PublishTest extends TestCase

--- a/tests/Request/DeclarePublisherRequestV1Test.php
+++ b/tests/Request/DeclarePublisherRequestV1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class DeclarePublisherRequestV1Test extends TestCase

--- a/tests/Request/DeletePublisherRequestV1Test.php
+++ b/tests/Request/DeletePublisherRequestV1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\DeletePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeletePublisherRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class DeletePublisherRequestV1Test extends TestCase

--- a/tests/Request/HeartbeatRequestV1Test.php
+++ b/tests/Request/HeartbeatRequestV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Request\HeartbeatRequestV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Request\HeartbeatRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class HeartbeatRequestV1Test extends TestCase

--- a/tests/Request/OpenRequestTest.php
+++ b/tests/Request/OpenRequestTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
 use PHPUnit\Framework\TestCase;
 
 class OpenRequestTest extends TestCase

--- a/tests/Request/PeerPropertiesToStreamBufferV1Test.php
+++ b/tests/Request/PeerPropertiesToStreamBufferV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\PeerPropertiesToStreamBufferV1;
-use CrazyGoat\StreamyCarrot\VO\KeyValue;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\VO\KeyValue;
 use PHPUnit\Framework\TestCase;
 
 class PeerPropertiesToStreamBufferV1Test extends TestCase

--- a/tests/Request/PublishRequestV1Test.php
+++ b/tests/Request/PublishRequestV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\PublishRequestV1;
-use CrazyGoat\StreamyCarrot\VO\PublishedMessage;
+use CrazyGoat\RabbitStream\Request\PublishRequestV1;
+use CrazyGoat\RabbitStream\VO\PublishedMessage;
 use PHPUnit\Framework\TestCase;
 
 class PublishRequestV1Test extends TestCase

--- a/tests/Request/PublishRequestV2Test.php
+++ b/tests/Request/PublishRequestV2Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\PublishRequestV2;
-use CrazyGoat\StreamyCarrot\VO\PublishedMessageV2;
+use CrazyGoat\RabbitStream\Request\PublishRequestV2;
+use CrazyGoat\RabbitStream\VO\PublishedMessageV2;
 use PHPUnit\Framework\TestCase;
 
 class PublishRequestV2Test extends TestCase

--- a/tests/Request/SaslAuthenticateRequestV1Test.php
+++ b/tests/Request/SaslAuthenticateRequestV1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class SaslAuthenticateRequestV1Test extends TestCase

--- a/tests/Request/SaslHandshakeRequestV1Test.php
+++ b/tests/Request/SaslHandshakeRequestV1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class SaslHandshakeRequestV1Test extends TestCase

--- a/tests/Request/TuneRequestV1Test.php
+++ b/tests/Request/TuneRequestV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Request;
+namespace CrazyGoat\RabbitStream\Tests\Request;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
 use PHPUnit\Framework\TestCase;
 
 class TuneRequestV1Test extends TestCase

--- a/tests/Response/ConsumerUpdateQueryV1Test.php
+++ b/tests/Response/ConsumerUpdateQueryV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\ConsumerUpdateQueryV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\ConsumerUpdateQueryV1;
 use PHPUnit\Framework\TestCase;
 
 class ConsumerUpdateQueryV1Test extends TestCase

--- a/tests/Response/DeclarePublisherResponseV1Test.php
+++ b/tests/Response/DeclarePublisherResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\DeclarePublisherResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\DeclarePublisherResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class DeclarePublisherResponseV1Test extends TestCase

--- a/tests/Response/DeletePublisherResponseV1Test.php
+++ b/tests/Response/DeletePublisherResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\DeletePublisherResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\DeletePublisherResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class DeletePublisherResponseV1Test extends TestCase

--- a/tests/Response/MetadataUpdateResponseV1Test.php
+++ b/tests/Response/MetadataUpdateResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\MetadataUpdateResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\MetadataUpdateResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class MetadataUpdateResponseV1Test extends TestCase

--- a/tests/Response/OpenResponseV1Test.php
+++ b/tests/Response/OpenResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class OpenResponseV1Test extends TestCase

--- a/tests/Response/PeerPropertiesResponseV1Test.php
+++ b/tests/Response/PeerPropertiesResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\PeerPropertiesResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class PeerPropertiesResponseV1Test extends TestCase

--- a/tests/Response/PublishConfirmResponseV1Test.php
+++ b/tests/Response/PublishConfirmResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\PublishConfirmResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\PublishConfirmResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class PublishConfirmResponseV1Test extends TestCase

--- a/tests/Response/PublishErrorResponseV1Test.php
+++ b/tests/Response/PublishErrorResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\PublishErrorResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\PublishErrorResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class PublishErrorResponseV1Test extends TestCase

--- a/tests/Response/SaslAuthenticateResponseV1Test.php
+++ b/tests/Response/SaslAuthenticateResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\SaslAuthenticateResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class SaslAuthenticateResponseV1Test extends TestCase

--- a/tests/Response/SaslHandshakeResponseV1Test.php
+++ b/tests/Response/SaslHandshakeResponseV1Test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Buffer\ReadBuffer;
-use CrazyGoat\StreamyCarrot\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class SaslHandshakeResponseV1Test extends TestCase

--- a/tests/Response/TuneResponseV1Test.php
+++ b/tests/Response/TuneResponseV1Test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CrazyGoat\StreamyCarrot\Tests\Response;
+namespace CrazyGoat\RabbitStream\Tests\Response;
 
-use CrazyGoat\StreamyCarrot\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use PHPUnit\Framework\TestCase;
 
 class TuneResponseV1Test extends TestCase


### PR DESCRIPTION
This PR renames the project from StreamyCarrot to RabbitStream to align with the repository name.

Changes:
- Package name: crazy-goat/streamy-carrot -> crazy-goat/rabbit-stream
- Namespace: CrazyGoat\StreamyCarrot -> CrazyGoat\RabbitStream
- All PHP files, tests, examples updated
- README and CHANGELOG updated

All 62 unit tests pass.

Closes #26