### PR TITLE
feat: implement StoreOffset command (0x000a)

### DIFF
--- a/examples/store_offset.php
+++ b/examples/store_offset.php
@@ -1,0 +1,40 @@
+<?php
+
+use CrazyGoat\RabbitStream\Client\StreamClient;
+use CrazyGoat\RabbitStream\Client\StreamClientConfig;
+use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
+
+include __DIR__ . '/../vendor/autoload.php';
+
+$host = getenv('RABBITMQ_HOST') ?: '127.0.0.1';
+$port = (int)(getenv('RABBITMQ_PORT') ?: 5552);
+
+echo "Connecting to RabbitMQ Stream at $host:$port...\n";
+
+try {
+    $client = StreamClient::connect(new StreamClientConfig(
+        host: $host,
+        port: $port,
+    ));
+
+    echo "Connected successfully.\n";
+
+    // Store an offset for a consumer reference
+    // This allows resuming consumption from a known position
+    $request = new StoreOffsetRequestV1(
+        reference: 'my-consumer-ref',
+        stream: 'test-stream',
+        offset: 100
+    );
+
+    echo "Storing offset...\n";
+    $client->sendMessage($request);
+
+    echo "Offset stored successfully.\n";
+
+    $client->close();
+    echo "Done.\n";
+} catch (\Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/src/Request/StoreOffsetRequestV1.php
+++ b/src/Request/StoreOffsetRequestV1.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Request;
+
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+
+class StoreOffsetRequestV1 implements ToStreamBufferInterface, KeyVersionInterface
+{
+    use V1Trait;
+    use CommandTrait;
+
+    public function __construct(
+        private string $reference,
+        private string $stream,
+        private int $offset
+    ) {}
+
+    public function toStreamBuffer(): WriteBuffer
+    {
+        return self::getKeyVersion()
+            ->addString($this->reference)
+            ->addString($this->stream)
+            ->addUInt64($this->offset);
+    }
+
+    static public function getKey(): int
+    {
+        return KeyEnum::STORE_OFFSET->value;
+    }
+}

--- a/tests/Request/StoreOffsetRequestV1Test.php
+++ b/tests/Request/StoreOffsetRequestV1Test.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Request;
+
+use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
+use PHPUnit\Framework\TestCase;
+
+class StoreOffsetRequestV1Test extends TestCase
+{
+    public function testSerializesCorrectly(): void
+    {
+        $request = new StoreOffsetRequestV1(
+            'my-reference',
+            'my-stream',
+            1234567890
+        );
+
+        $bytes = $request->toStreamBuffer()->getContents();
+
+        $expected = pack('n', 0x000a)                  // key
+            . pack('n', 1)                             // version
+            . pack('n', strlen('my-reference'))        // reference length
+            . 'my-reference'                           // reference
+            . pack('n', strlen('my-stream'))           // stream length
+            . 'my-stream'                              // stream
+            . pack('J', 1234567890);                   // offset (uint64 big-endian)
+
+        $this->assertSame($expected, $bytes);
+    }
+}


### PR DESCRIPTION
Implementuje komendę StoreOffset (0x000a) zgodnie z issue #19.

## Zmiany
- `src/Request/StoreOffsetRequestV1.php` - request class
- `tests/Request/StoreOffsetRequestV1Test.php` - test jednostkowy
- `examples/store_offset.php` - przykład użycia

## Opis
StoreOffset pozwala zapisać offset konsumenta na serwerze, umożliwiając wznowienie konsumpcji z znanego miejsca. Serwer nie odpowiada na tę komendę.

Closes #19