### PR TITLE
feat: implement Create Super Stream command (0x001d)

### DIFF
--- a/src/Buffer/WriteBuffer.php
+++ b/src/Buffer/WriteBuffer.php
@@ -130,6 +130,16 @@ class WriteBuffer
         return $this;
     }
 
+    public function addStringArray(string ...$strings): self
+    {
+        $this->addInt32(count($strings));
+        foreach ($strings as $string) {
+            $this->addString($string);
+        }
+
+        return $this;
+    }
+
     public function addRaw(string $value): self
     {
         $this->buffer .= $value;

--- a/src/Request/CreateSuperStreamRequestV1.php
+++ b/src/Request/CreateSuperStreamRequestV1.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Request;
+
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\VO\KeyValue;
+
+class CreateSuperStreamRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+{
+    use CorrelationTrait;
+    use V1Trait;
+    use CommandTrait;
+
+    /**
+     * @param string[] $partitions
+     * @param string[] $bindingKeys
+     * @param array<string, string> $arguments
+     */
+    public function __construct(
+        private string $name,
+        private array $partitions = [],
+        private array $bindingKeys = [],
+        private array $arguments = []
+    ) {}
+
+    public function toStreamBuffer(): WriteBuffer
+    {
+        $buffer = self::getKeyVersion($this->getCorrelationId())
+            ->addString($this->name)
+            ->addStringArray(...$this->partitions)
+            ->addStringArray(...$this->bindingKeys);
+
+        $keyValues = [];
+        foreach ($this->arguments as $key => $value) {
+            $keyValues[] = new KeyValue($key, $value);
+        }
+
+        $buffer->addArray(...$keyValues);
+
+        return $buffer;
+    }
+
+    static public function getKey(): int
+    {
+        return KeyEnum::CREATE_SUPER_STREAM->value;
+    }
+}

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Response;
+
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+
+class CreateSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+{
+    use CorrelationTrait;
+    use CommandTrait;
+    use V1Trait;
+
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    {
+        self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
+        $correlationId = $buffer->getUint32();
+        self::isResponseCodeOk($buffer->getUint16());
+        $object = new self();
+        $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    static public function getKey(): int
+    {
+        return KeyEnum::CREATE_SUPER_STREAM_RESPONSE->value;
+    }
+}

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -22,6 +22,7 @@ use CrazyGoat\RabbitStream\Response\QueryOffsetResponseV1;
 use CrazyGoat\RabbitStream\Response\QueryPublisherSequenceResponseV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
@@ -71,6 +72,7 @@ class ResponseBuilder
             KeyEnum::PEER_PROPERTIES_RESPONSE => PeerPropertiesResponseV1::fromStreamBuffer($responseBuffer),
             KeyEnum::STREAM_STATS_RESPONSE => StreamStatsResponseV1::fromStreamBuffer($responseBuffer),
             KeyEnum::PARTITIONS_RESPONSE => PartitionsResponseV1::fromStreamBuffer($responseBuffer),
+            KeyEnum::CREATE_SUPER_STREAM_RESPONSE => CreateSuperStreamResponseV1::fromStreamBuffer($responseBuffer),
             default => throw new \Exception('Unexpected match value'),
         };
     }

--- a/tests/E2E/CreateSuperStreamTest.php
+++ b/tests/E2E/CreateSuperStreamTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PartitionsRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\PartitionsResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class CreateSuperStreamTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    private function connectAndOpen(): StreamConnection
+    {
+        $connection = new StreamConnection(self::$host, self::$port);
+        $connection->connect();
+
+        $connection->sendMessage(new PeerPropertiesToStreamBufferV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslHandshakeRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $connection->readMessage();
+
+        $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+        $connection->sendMessage(new TuneRequestV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        $connection->sendMessage(new OpenRequest('/'));
+        $connection->readMessage();
+
+        return $connection;
+    }
+
+    public function testCreateSuperStream(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $superStreamName = 'test-super-stream-' . uniqid();
+        $partition1 = $superStreamName . '-partition1';
+        $partition2 = $superStreamName . '-partition2';
+        $partition3 = $superStreamName . '-partition3';
+
+        $connection->sendMessage(new CreateSuperStreamRequestV1(
+            $superStreamName,
+            [$partition1, $partition2, $partition3],
+            ['key1', 'key2', 'key3'],
+            ['max-length-bytes' => '1000000']
+        ));
+        $response = $connection->readMessage();
+
+        $this->assertInstanceOf(CreateSuperStreamResponseV1::class, $response);
+
+        // Verify we can query partitions
+        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
+        $partitionsResponse = $connection->readMessage();
+
+        $this->assertInstanceOf(PartitionsResponseV1::class, $partitionsResponse);
+        $streams = $partitionsResponse->getStreams();
+        $this->assertCount(3, $streams);
+        $this->assertContains($partition1, $streams);
+        $this->assertContains($partition2, $streams);
+        $this->assertContains($partition3, $streams);
+
+        $connection->close();
+    }
+
+    public function testCreateDuplicateSuperStreamThrows(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $superStreamName = 'test-duplicate-super-stream-' . uniqid();
+
+        // First create should succeed
+        $connection->sendMessage(new CreateSuperStreamRequestV1(
+            $superStreamName,
+            [$superStreamName . '-p1', $superStreamName . '-p2'],
+            ['k1', 'k2']
+        ));
+        $connection->readMessage();
+
+        // Second create should fail
+        $this->expectException(\Exception::class);
+        $connection->sendMessage(new CreateSuperStreamRequestV1(
+            $superStreamName,
+            [$superStreamName . '-p1', $superStreamName . '-p2'],
+            ['k1', 'k2']
+        ));
+        $connection->readMessage();
+
+        $connection->close();
+    }
+}

--- a/tests/Request/CreateSuperStreamRequestV1Test.php
+++ b/tests/Request/CreateSuperStreamRequestV1Test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Request;
+
+use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use PHPUnit\Framework\TestCase;
+
+class CreateSuperStreamRequestV1Test extends TestCase
+{
+    public function testSerializesCorrectly(): void
+    {
+        $request = new CreateSuperStreamRequestV1(
+            'my-super-stream',
+            ['partition1', 'partition2', 'partition3'],
+            ['key1', 'key2', 'key3'],
+            ['max-length-bytes' => '1000000']
+        );
+        $request->withCorrelationId(42);
+
+        $bytes = $request->toStreamBuffer()->getContents();
+
+        $expected = pack('n', 0x001d)   // key (CREATE_SUPER_STREAM)
+            . pack('n', 1)              // version
+            . pack('N', 42)             // correlationId
+            . pack('n', 15)             // super stream name length
+            . 'my-super-stream'         // super stream name
+            . pack('N', 3)              // 3 partitions
+            . pack('n', 10)             // partition 1 name length
+            . 'partition1'               // partition 1 name
+            . pack('n', 10)             // partition 2 name length
+            . 'partition2'               // partition 2 name
+            . pack('n', 10)             // partition 3 name length
+            . 'partition3'              // partition 3 name
+            . pack('N', 3)              // 3 binding keys
+            . pack('n', 4)              // binding key 1 length
+            . 'key1'                    // binding key 1
+            . pack('n', 4)              // binding key 2 length
+            . 'key2'                    // binding key 2
+            . pack('n', 4)              // binding key 3 length
+            . 'key3'                    // binding key 3
+            . pack('N', 1)              // 1 argument
+            . pack('n', 16)             // argument key length
+            . 'max-length-bytes'        // argument key
+            . pack('n', 7)              // argument value length
+            . '1000000';               // argument value
+
+        $this->assertSame($expected, $bytes);
+    }
+
+    public function testSerializesWithEmptyArrays(): void
+    {
+        $request = new CreateSuperStreamRequestV1('empty-super-stream');
+        $request->withCorrelationId(1);
+
+        $bytes = $request->toStreamBuffer()->getContents();
+
+        $expected = pack('n', 0x001d)   // key
+            . pack('n', 1)              // version
+            . pack('N', 1)              // correlationId
+            . pack('n', 18)             // super stream name length
+            . 'empty-super-stream'      // super stream name
+            . pack('N', 0)              // 0 partitions
+            . pack('N', 0)              // 0 binding keys
+            . pack('N', 0);            // 0 arguments
+
+        $this->assertSame($expected, $bytes);
+    }
+}

--- a/tests/Response/CreateSuperStreamResponseV1Test.php
+++ b/tests/Response/CreateSuperStreamResponseV1Test.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Response;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
+use PHPUnit\Framework\TestCase;
+
+class CreateSuperStreamResponseV1Test extends TestCase
+{
+    public function testDeserializesCorrectly(): void
+    {
+        $raw = pack('n', 0x801d)           // key (CREATE_SUPER_STREAM_RESPONSE)
+            . pack('n', 1)                  // version
+            . pack('N', 42)                 // correlationId
+            . pack('n', 0x0001);            // response code (OK)
+
+        $response = CreateSuperStreamResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+
+        $this->assertInstanceOf(CreateSuperStreamResponseV1::class, $response);
+        $this->assertSame(42, $response->getCorrelationId());
+    }
+
+    public function testThrowsOnNonOkResponseCode(): void
+    {
+        $raw = pack('n', 0x801d)           // key
+            . pack('n', 1)                  // version
+            . pack('N', 42)                 // correlationId
+            . pack('n', 0x0005);            // response code (Stream already exists)
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unexpected response code');
+
+        CreateSuperStreamResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the Create Super Stream command (0x001d) to create partitioned super streams on RabbitMQ.

## Changes
- **src/Request/CreateSuperStreamRequestV1.php** - Request class with super stream name, partitions array, binding keys array, and optional arguments
- **src/Response/CreateSuperStreamResponseV1.php** - Response class handling server confirmation
- **src/Buffer/WriteBuffer.php** - Added `addStringArray()` helper method for serializing string arrays
- **src/Enum/KeyEnum.php** - Already had `CREATE_SUPER_STREAM_RESPONSE = 0x801d`
- **src/ResponseBuilder.php** - Registered response handler
- **tests/Request/CreateSuperStreamRequestV1Test.php** - Unit tests for request serialization
- **tests/Response/CreateSuperStreamResponseV1Test.php** - Unit tests for response deserialization
- **tests/E2E/CreateSuperStreamTest.php** - E2E tests creating super streams and verifying via Partitions command

## Protocol Structure
```
CreateSuperStream => Key Version CorrelationId Name [Partition] [BindingKey] Arguments
  Name => string
  Partition => string
  BindingKey => string
  Arguments => [Argument] (key-value strings)
CreateSuperStreamResponse => Key Version CorrelationId ResponseCode
```

## Testing
- ✅ All 116 unit tests pass
- ✅ All 35 E2E tests pass (including 2 new CreateSuperStream tests)
- ✅ Partitions E2E test now fully enabled (was skipped, now tests actual super stream)

## Related
Closes #7