### PR TITLE
feat: implement DeleteSuperStream command (0x001e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Protocol reference: https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/r
 | Metadata        | 0x000f | ✅      | ✅       |
 | MetadataUpdate  | 0x0010 | —       | ✅       |
 | CreateSuperStream | 0x001d | ✅      | ✅       |
-| DeleteSuperStream | 0x001e | ❌    | ❌       |
+| DeleteSuperStream | 0x001e | ✅    | ✅       |
 | StreamStats     | 0x001c | ✅      | ✅       |
 
 ### Routing (Super Streams)

--- a/src/Request/DeleteSuperStreamRequestV1.php
+++ b/src/Request/DeleteSuperStreamRequestV1.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Request;
+
+use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+
+class DeleteSuperStreamRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+{
+    use CorrelationTrait;
+    use V1Trait;
+    use CommandTrait;
+
+    public function __construct(private string $name) {}
+
+    public function toStreamBuffer(): WriteBuffer
+    {
+        return self::getKeyVersion($this->getCorrelationId())
+            ->addString($this->name);
+    }
+
+    static public function getKey(): int
+    {
+        return KeyEnum::DELETE_SUPER_STREAM->value;
+    }
+}

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Response;
+
+use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Trait\CommandTrait;
+use CrazyGoat\RabbitStream\Trait\CorrelationInterface;
+use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
+use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
+use CrazyGoat\RabbitStream\Trait\V1Trait;
+
+class DeleteSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+{
+    use CorrelationTrait;
+    use CommandTrait;
+    use V1Trait;
+
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    {
+        self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
+        $correlationId = $buffer->getUint32();
+        self::isResponseCodeOk($buffer->getUint16());
+        $object = new self();
+        $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    static public function getKey(): int
+    {
+        return KeyEnum::DELETE_SUPER_STREAM_RESPONSE->value;
+    }
+}

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -23,6 +23,7 @@ use CrazyGoat\RabbitStream\Response\QueryPublisherSequenceResponseV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\CreateResponseV1;
 use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteSuperStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
@@ -73,6 +74,7 @@ class ResponseBuilder
             KeyEnum::STREAM_STATS_RESPONSE => StreamStatsResponseV1::fromStreamBuffer($responseBuffer),
             KeyEnum::PARTITIONS_RESPONSE => PartitionsResponseV1::fromStreamBuffer($responseBuffer),
             KeyEnum::CREATE_SUPER_STREAM_RESPONSE => CreateSuperStreamResponseV1::fromStreamBuffer($responseBuffer),
+            KeyEnum::DELETE_SUPER_STREAM_RESPONSE => DeleteSuperStreamResponseV1::fromStreamBuffer($responseBuffer),
             default => throw new \Exception('Unexpected match value'),
         };
     }

--- a/tests/E2E/DeleteSuperStreamTest.php
+++ b/tests/E2E/DeleteSuperStreamTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PartitionsRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\PartitionsResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class DeleteSuperStreamTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    private function connectAndOpen(): StreamConnection
+    {
+        $connection = new StreamConnection(self::$host, self::$port);
+        $connection->connect();
+
+        $connection->sendMessage(new PeerPropertiesToStreamBufferV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslHandshakeRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $connection->readMessage();
+
+        $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+        $connection->sendMessage(new TuneRequestV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        $connection->sendMessage(new OpenRequest('/'));
+        $connection->readMessage();
+
+        return $connection;
+    }
+
+    public function testDeleteSuperStream(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $superStreamName = 'test-delete-super-stream-' . uniqid();
+        $partition1 = $superStreamName . '-partition1';
+        $partition2 = $superStreamName . '-partition2';
+        $partition3 = $superStreamName . '-partition3';
+
+        // Create super stream
+        $connection->sendMessage(new CreateSuperStreamRequestV1(
+            $superStreamName,
+            [$partition1, $partition2, $partition3],
+            ['key1', 'key2', 'key3'],
+            ['max-length-bytes' => '1000000']
+        ));
+        $createResponse = $connection->readMessage();
+        $this->assertInstanceOf(CreateSuperStreamResponseV1::class, $createResponse);
+
+        // Verify super stream exists by querying partitions
+        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
+        $partitionsResponse = $connection->readMessage();
+        $this->assertInstanceOf(PartitionsResponseV1::class, $partitionsResponse);
+        $this->assertCount(3, $partitionsResponse->getStreams());
+
+        // Delete super stream
+        $connection->sendMessage(new DeleteSuperStreamRequestV1($superStreamName));
+        $deleteResponse = $connection->readMessage();
+        $this->assertInstanceOf(DeleteSuperStreamResponseV1::class, $deleteResponse);
+
+        // Verify super stream no longer exists (partitions query should fail)
+        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
+        $this->expectException(\Exception::class);
+        $connection->readMessage();
+
+        $connection->close();
+    }
+
+    public function testDeleteNonExistentSuperStreamThrows(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $superStreamName = 'test-delete-nonexistent-super-stream-' . uniqid();
+
+        // Delete should fail for non-existent super stream
+        $this->expectException(\Exception::class);
+        $connection->sendMessage(new DeleteSuperStreamRequestV1($superStreamName));
+        $connection->readMessage();
+
+        $connection->close();
+    }
+}

--- a/tests/Request/DeleteSuperStreamRequestV1Test.php
+++ b/tests/Request/DeleteSuperStreamRequestV1Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Request;
+
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
+use PHPUnit\Framework\TestCase;
+
+class DeleteSuperStreamRequestV1Test extends TestCase
+{
+    public function testSerializesCorrectly(): void
+    {
+        $request = new DeleteSuperStreamRequestV1('my-super-stream');
+        $request->withCorrelationId(42);
+
+        $bytes = $request->toStreamBuffer()->getContents();
+
+        $expected = pack('n', 0x001e)   // key (DELETE_SUPER_STREAM)
+            . pack('n', 1)              // version
+            . pack('N', 42)             // correlationId
+            . pack('n', 15)             // super stream name length
+            . 'my-super-stream';        // super stream name
+
+        $this->assertSame($expected, $bytes);
+    }
+}

--- a/tests/Response/DeleteSuperStreamResponseV1Test.php
+++ b/tests/Response/DeleteSuperStreamResponseV1Test.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Response;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Response\DeleteSuperStreamResponseV1;
+use PHPUnit\Framework\TestCase;
+
+class DeleteSuperStreamResponseV1Test extends TestCase
+{
+    public function testDeserializesCorrectly(): void
+    {
+        $raw = pack('n', 0x801e)    // key (DELETE_SUPER_STREAM_RESPONSE)
+            . pack('n', 1)          // version
+            . pack('N', 42)         // correlationId
+            . pack('n', 0x0001);   // responseCode OK
+
+        $response = DeleteSuperStreamResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+
+        $this->assertInstanceOf(DeleteSuperStreamResponseV1::class, $response);
+        $this->assertSame(42, $response->getCorrelationId());
+    }
+
+    public function testThrowsOnErrorResponseCode(): void
+    {
+        $raw = pack('n', 0x801e)
+            . pack('n', 1)
+            . pack('N', 1)
+            . pack('n', 0x0002); // Super stream does not exist
+
+        $this->expectException(\Exception::class);
+        DeleteSuperStreamResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+    }
+}


### PR DESCRIPTION
## Summary

Implement the DeleteSuperStream command (0x001e) to allow deleting super streams in RabbitMQ Streams.

## Changes

- **Request:** `DeleteSuperStreamRequestV1` - sends delete request with super stream name
- **Response:** `DeleteSuperStreamResponseV1` - handles server response
- **Registration:** Added to `ResponseBuilder` for proper dispatching
- **Tests:** 
  - Unit tests for request serialization and response deserialization
  - E2E tests for actual delete operations against RabbitMQ
- **Docs:** Updated README to mark command as ✅ implemented

## Testing

```bash
# Unit tests
./vendor/bin/phpunit tests/Request/DeleteSuperStreamRequestV1Test.php
./vendor/bin/phpunit tests/Response/DeleteSuperStreamResponseV1Test.php

# E2E tests (requires RabbitMQ)
./run-e2e.sh
```

All 119 unit tests pass ✅

## Protocol Reference

Command key: `0x001e` (DELETE_SUPER_STREAM)  
Response key: `0x801e` (DELETE_SUPER_STREAM_RESPONSE)

Closes #11