### PR TITLE
feat: add toArray()/fromArray() to all Request/Response/VO classes (#47)

### DIFF
--- a/src/Buffer/FromArrayInterface.php
+++ b/src/Buffer/FromArrayInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Buffer;
+
+interface FromArrayInterface
+{
+    public static function fromArray(array $data): static;
+}

--- a/src/Buffer/ToArrayInterface.php
+++ b/src/Buffer/ToArrayInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Buffer;
+
+interface ToArrayInterface
+{
+    public function toArray(): array;
+}

--- a/src/Request/CloseRequestV1.php
+++ b/src/Request/CloseRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CloseRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class CloseRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -28,6 +29,14 @@ class CloseRequestV1 implements ToStreamBufferInterface, CorrelationInterface, K
         return self::getKeyVersion($this->getCorrelationId())
             ->addUInt16($this->closingCode)
             ->addString($this->closingReason);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'closingCode' => $this->closingCode,
+            'closingReason' => $this->closingReason,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/ConsumerUpdateReplyV1.php
+++ b/src/Request/ConsumerUpdateReplyV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class ConsumerUpdateReplyV1 implements ToStreamBufferInterface, KeyVersionInterface
+class ConsumerUpdateReplyV1 implements ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -30,6 +31,16 @@ class ConsumerUpdateReplyV1 implements ToStreamBufferInterface, KeyVersionInterf
             ->addUInt16($this->responseCode)
             ->addUInt16($this->offsetType)
             ->addUInt64($this->offset);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'correlationId' => $this->correlationId,
+            'responseCode' => $this->responseCode,
+            'offsetType' => $this->offsetType,
+            'offset' => $this->offset,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/CreateRequestV1.php
+++ b/src/Request/CreateRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
-class CreateRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class CreateRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -39,6 +40,14 @@ class CreateRequestV1 implements ToStreamBufferInterface, CorrelationInterface, 
         $buffer->addArray(...$keyValues);
 
         return $buffer;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'stream' => $this->stream,
+            'arguments' => $this->arguments,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/CreateSuperStreamRequestV1.php
+++ b/src/Request/CreateSuperStreamRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
-class CreateSuperStreamRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class CreateSuperStreamRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -45,6 +46,16 @@ class CreateSuperStreamRequestV1 implements ToStreamBufferInterface, Correlation
         $buffer->addArray(...$keyValues);
 
         return $buffer;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'partitions' => $this->partitions,
+            'bindingKeys' => $this->bindingKeys,
+            'arguments' => $this->arguments,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/CreditRequestV1.php
+++ b/src/Request/CreditRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CreditRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class CreditRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -27,6 +28,14 @@ class CreditRequestV1 implements ToStreamBufferInterface, CorrelationInterface, 
         return self::getKeyVersion($this->getCorrelationId())
             ->addUInt8($this->subscriptionId)
             ->addUInt16($this->credit);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'subscriptionId' => $this->subscriptionId,
+            'credit' => $this->credit,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/DeclarePublisherRequestV1.php
+++ b/src/Request/DeclarePublisherRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeclarePublisherRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class DeclarePublisherRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -29,6 +30,15 @@ class DeclarePublisherRequestV1 implements ToStreamBufferInterface, CorrelationI
             ->addUInt8($this->publisherId)
             ->addString($this->publisherReference ?? '')
             ->addString($this->stream);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'publisherId' => $this->publisherId,
+            'publisherReference' => $this->publisherReference,
+            'stream' => $this->stream,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/DeletePublisherRequestV1.php
+++ b/src/Request/DeletePublisherRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeletePublisherRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class DeletePublisherRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class DeletePublisherRequestV1 implements ToStreamBufferInterface, CorrelationIn
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addUInt8($this->publisherId);
+    }
+
+    public function toArray(): array
+    {
+        return ['publisherId' => $this->publisherId];
     }
 
     static public function getKey(): int

--- a/src/Request/DeleteStreamRequestV1.php
+++ b/src/Request/DeleteStreamRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeleteStreamRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class DeleteStreamRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class DeleteStreamRequestV1 implements ToStreamBufferInterface, CorrelationInter
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->stream);
+    }
+
+    public function toArray(): array
+    {
+        return ['stream' => $this->stream];
     }
 
     static public function getKey(): int

--- a/src/Request/DeleteSuperStreamRequestV1.php
+++ b/src/Request/DeleteSuperStreamRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeleteSuperStreamRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class DeleteSuperStreamRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class DeleteSuperStreamRequestV1 implements ToStreamBufferInterface, Correlation
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->name);
+    }
+
+    public function toArray(): array
+    {
+        return ['name' => $this->name];
     }
 
     static public function getKey(): int

--- a/src/Request/ExchangeCommandVersionsRequestV1.php
+++ b/src/Request/ExchangeCommandVersionsRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\CommandVersion;
 
-class ExchangeCommandVersionsRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class ExchangeCommandVersionsRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -27,6 +28,11 @@ class ExchangeCommandVersionsRequestV1 implements ToStreamBufferInterface, Corre
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addArray(...$this->commands);
+    }
+
+    public function toArray(): array
+    {
+        return ['commands' => array_map(fn(CommandVersion $cv) => $cv->toArray(), $this->commands)];
     }
 
     static public function getKey(): int

--- a/src/Request/HeartbeatRequestV1.php
+++ b/src/Request/HeartbeatRequestV1.php
@@ -4,6 +4,7 @@ namespace CrazyGoat\RabbitStream\Request;
 
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class HeartbeatRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, KeyVersionInterface
+class HeartbeatRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -24,6 +25,11 @@ class HeartbeatRequestV1 implements FromStreamBufferInterface, ToStreamBufferInt
     public function toStreamBuffer(): WriteBuffer
     {
         return self::getKeyVersion();
+    }
+
+    public function toArray(): array
+    {
+        return [];
     }
 
     public static function fromStreamBuffer(ReadBuffer $buffer): ?object

--- a/src/Request/MetadataRequestV1.php
+++ b/src/Request/MetadataRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class MetadataRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class MetadataRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -32,6 +33,11 @@ class MetadataRequestV1 implements ToStreamBufferInterface, CorrelationInterface
         }
 
         return $buffer;
+    }
+
+    public function toArray(): array
+    {
+        return ['streams' => $this->streams];
     }
 
     static public function getKey(): int

--- a/src/Request/OpenRequest.php
+++ b/src/Request/OpenRequest.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class OpenRequest implements KeyVersionInterface, ToStreamBufferInterface, CorrelationInterface
+class OpenRequest implements KeyVersionInterface, ToStreamBufferInterface, ToArrayInterface, CorrelationInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -25,6 +26,11 @@ class OpenRequest implements KeyVersionInterface, ToStreamBufferInterface, Corre
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->vhost);
+    }
+
+    public function toArray(): array
+    {
+        return ['vhost' => $this->vhost];
     }
 
     static public function getKey(): int

--- a/src/Request/PartitionsRequestV1.php
+++ b/src/Request/PartitionsRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class PartitionsRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class PartitionsRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class PartitionsRequestV1 implements ToStreamBufferInterface, CorrelationInterfa
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->superStream);
+    }
+
+    public function toArray(): array
+    {
+        return ['superStream' => $this->superStream];
     }
 
     static public function getKey(): int

--- a/src/Request/PeerPropertiesToStreamBufferV1.php
+++ b/src/Request/PeerPropertiesToStreamBufferV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
-class PeerPropertiesToStreamBufferV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class PeerPropertiesToStreamBufferV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -29,6 +30,11 @@ class PeerPropertiesToStreamBufferV1 implements ToStreamBufferInterface, Correla
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addArray(...$this->keyValues);
+    }
+
+    public function toArray(): array
+    {
+        return ['properties' => array_map(fn(KeyValue $kv) => $kv->toArray(), $this->keyValues)];
     }
 
     static public function getKey(): int

--- a/src/Request/PublishRequestV1.php
+++ b/src/Request/PublishRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -10,7 +11,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\PublishedMessage;
 
-class PublishRequestV1 implements ToStreamBufferInterface, KeyVersionInterface
+class PublishRequestV1 implements ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -27,6 +28,14 @@ class PublishRequestV1 implements ToStreamBufferInterface, KeyVersionInterface
         return self::getKeyVersion()
             ->addUInt8($this->publisherId)
             ->addArray(...$this->messages);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'publisherId' => $this->publisherId,
+            'messages' => array_map(fn(PublishedMessage $m) => $m->toArray(), $this->messages),
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/PublishRequestV2.php
+++ b/src/Request/PublishRequestV2.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -10,7 +11,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\PublishedMessageV2;
 
-class PublishRequestV2 implements ToStreamBufferInterface, KeyVersionInterface
+class PublishRequestV2 implements ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -27,6 +28,14 @@ class PublishRequestV2 implements ToStreamBufferInterface, KeyVersionInterface
         return self::getKeyVersion()
             ->addUInt8($this->publisherId)
             ->addArray(...$this->messages);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'publisherId' => $this->publisherId,
+            'messages' => array_map(fn(PublishedMessageV2 $m) => $m->toArray(), $this->messages),
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/QueryOffsetRequestV1.php
+++ b/src/Request/QueryOffsetRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class QueryOffsetRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class QueryOffsetRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -27,6 +28,14 @@ class QueryOffsetRequestV1 implements ToStreamBufferInterface, CorrelationInterf
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->reference)
             ->addString($this->stream);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'reference' => $this->reference,
+            'stream' => $this->stream,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/QueryPublisherSequenceRequestV1.php
+++ b/src/Request/QueryPublisherSequenceRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class QueryPublisherSequenceRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class QueryPublisherSequenceRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -27,6 +28,14 @@ class QueryPublisherSequenceRequestV1 implements ToStreamBufferInterface, Correl
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->reference)
             ->addString($this->stream);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'reference' => $this->reference,
+            'stream' => $this->stream,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/ResolveOffsetSpecRequestV1.php
+++ b/src/Request/ResolveOffsetSpecRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
 
-class ResolveOffsetSpecRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class ResolveOffsetSpecRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -29,6 +30,14 @@ class ResolveOffsetSpecRequestV1 implements ToStreamBufferInterface, Correlation
             ->addString($this->stream)
             ->addRaw($this->offsetSpec->toStreamBuffer()->getContents())
             ->addUInt32(0); // Properties array length (0 = empty array)
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'stream' => $this->stream,
+            'offsetSpec' => $this->offsetSpec->toArray(),
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/RouteRequestV1.php
+++ b/src/Request/RouteRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class RouteRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class RouteRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -27,6 +28,14 @@ class RouteRequestV1 implements ToStreamBufferInterface, CorrelationInterface, K
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->routingKey)
             ->addString($this->superStream);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'routingKey' => $this->routingKey,
+            'superStream' => $this->superStream,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/SaslAuthenticateRequestV1.php
+++ b/src/Request/SaslAuthenticateRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class SaslAuthenticateRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class SaslAuthenticateRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -25,6 +26,15 @@ class SaslAuthenticateRequestV1 implements ToStreamBufferInterface, CorrelationI
         return  self::getKeYVersion($this->getCorrelationId())
             ->addString($this->mechanism)
             ->addBytes("\0" . $this->username . "\0" . $this->password);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'mechanism' => $this->mechanism,
+            'username' => $this->username,
+            'password' => $this->password,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/SaslHandshakeRequestV1.php
+++ b/src/Request/SaslHandshakeRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class SaslHandshakeRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class SaslHandshakeRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -20,6 +21,11 @@ class SaslHandshakeRequestV1 implements ToStreamBufferInterface, CorrelationInte
     public function toStreamBuffer(): WriteBuffer
     {
         return self::getKeyVersion($this->getCorrelationId());
+    }
+
+    public function toArray(): array
+    {
+        return [];
     }
 
     static public function getKey(): int

--- a/src/Request/StoreOffsetRequestV1.php
+++ b/src/Request/StoreOffsetRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class StoreOffsetRequestV1 implements ToStreamBufferInterface, KeyVersionInterface
+class StoreOffsetRequestV1 implements ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -26,6 +27,15 @@ class StoreOffsetRequestV1 implements ToStreamBufferInterface, KeyVersionInterfa
             ->addString($this->reference)
             ->addString($this->stream)
             ->addUInt64($this->offset);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'reference' => $this->reference,
+            'stream' => $this->stream,
+            'offset' => $this->offset,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/StreamStatsRequestV1.php
+++ b/src/Request/StreamStatsRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class StreamStatsRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class StreamStatsRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class StreamStatsRequestV1 implements ToStreamBufferInterface, CorrelationInterf
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->stream);
+    }
+
+    public function toArray(): array
+    {
+        return ['stream' => $this->stream];
     }
 
     static public function getKey(): int

--- a/src/Request/SubscribeRequestV1.php
+++ b/src/Request/SubscribeRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
 
-class SubscribeRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class SubscribeRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -32,6 +33,16 @@ class SubscribeRequestV1 implements ToStreamBufferInterface, CorrelationInterfac
             ->addString($this->stream)
             ->addRaw($this->offsetSpec->toStreamBuffer()->getContents())
             ->addUInt16($this->credit);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'subscriptionId' => $this->subscriptionId,
+            'stream' => $this->stream,
+            'offsetSpec' => $this->offsetSpec->toArray(),
+            'credit' => $this->credit,
+        ];
     }
 
     static public function getKey(): int

--- a/src/Request/TuneRequestV1.php
+++ b/src/Request/TuneRequestV1.php
@@ -4,6 +4,7 @@ namespace CrazyGoat\RabbitStream\Request;
 
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, KeyVersionInterface
+class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
     use CommandTrait;
@@ -47,5 +48,13 @@ class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterfac
     public function getHeartbeat(): int
     {
         return $this->heartbeat;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'frameMax' => $this->frameMax,
+            'heartbeat' => $this->heartbeat,
+        ];
     }
 }

--- a/src/Request/UnsubscribeRequestV1.php
+++ b/src/Request/UnsubscribeRequestV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Request;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class UnsubscribeRequestV1 implements ToStreamBufferInterface, CorrelationInterface, KeyVersionInterface
+class UnsubscribeRequestV1 implements ToStreamBufferInterface, ToArrayInterface, CorrelationInterface, KeyVersionInterface
 {
     use CorrelationTrait;
     use V1Trait;
@@ -23,6 +24,11 @@ class UnsubscribeRequestV1 implements ToStreamBufferInterface, CorrelationInterf
     {
         return self::getKeyVersion($this->getCorrelationId())
             ->addUInt8($this->subscriptionId);
+    }
+
+    public function toArray(): array
+    {
+        return ['subscriptionId' => $this->subscriptionId];
     }
 
     static public function getKey(): int

--- a/src/Response/CloseResponseV1.php
+++ b/src/Response/CloseResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CloseResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class CloseResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class CloseResponseV1 implements KeyVersionInterface, CorrelationInterface, From
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class ConsumerUpdateQueryV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class ConsumerUpdateQueryV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use CorrelationTrait;
@@ -37,6 +38,13 @@ class ConsumerUpdateQueryV1 implements KeyVersionInterface, CorrelationInterface
         $active = $buffer->getUint8() === 1;
         $object = new self($subscriptionId, $active);
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self($data['subscriptionId'], $data['active']);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/CreateResponseV1.php
+++ b/src/Response/CreateResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CreateResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class CreateResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class CreateResponseV1 implements KeyVersionInterface, CorrelationInterface, Fro
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CreateSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class CreateSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class CreateSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInt
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/CreditResponseV1.php
+++ b/src/Response/CreditResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
+class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use V1Trait;
@@ -34,6 +35,14 @@ class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
     public function getResponseCode(): int
     {
         return $this->responseCode;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->responseCode = $data['responseCode'];
+        $object->subscriptionId = $data['subscriptionId'];
+        return $object;
     }
 
     public function getSubscriptionId(): int

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeclarePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class DeclarePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class DeclarePublisherResponseV1 implements KeyVersionInterface, CorrelationInte
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeletePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class DeletePublisherResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class DeletePublisherResponseV1 implements KeyVersionInterface, CorrelationInter
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/DeleteStreamResponseV1.php
+++ b/src/Response/DeleteStreamResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeleteStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class DeleteStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class DeleteStreamResponseV1 implements KeyVersionInterface, CorrelationInterfac
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeleteSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class DeleteSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class DeleteSuperStreamResponseV1 implements KeyVersionInterface, CorrelationInt
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
+class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use V1Trait;
@@ -32,6 +33,11 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
         $subscriptionId = $buffer->getUint8();
         $chunkBytes = $buffer->getRemainingBytes();
         return new self($subscriptionId, $chunkBytes);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['subscriptionId'], $data['chunkBytes']);
     }
 
     static public function getKey(): int

--- a/src/Response/ExchangeCommandVersionsResponseV1.php
+++ b/src/Response/ExchangeCommandVersionsResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\CommandVersion;
 
-class ExchangeCommandVersionsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class ExchangeCommandVersionsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -41,6 +42,17 @@ class ExchangeCommandVersionsResponseV1 implements KeyVersionInterface, Correlat
         $object = new self($commands);
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $commands = array_map(
+            fn(array $c) => new CommandVersion($c['key'], $c['minVersion'], $c['maxVersion']),
+            $data['commands']
+        );
+        $object = new self($commands);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/MetadataResponseV1.php
+++ b/src/Response/MetadataResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -13,7 +14,7 @@ use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\Broker;
 use CrazyGoat\RabbitStream\VO\StreamMetadata;
 
-class MetadataResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class MetadataResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -56,6 +57,21 @@ class MetadataResponseV1 implements KeyVersionInterface, CorrelationInterface, F
         $object = new self($brokers, $streamMetadata);
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $brokers = array_map(
+            fn(array $b) => new Broker($b['reference'], $b['host'], $b['port']),
+            $data['brokers']
+        );
+        $streamMetadata = array_map(
+            fn(array $s) => new StreamMetadata($s['stream'], $s['responseCode'], $s['leaderReference'], $s['replicasReferences']),
+            $data['streamMetadata']
+        );
+        $object = new self($brokers, $streamMetadata);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
+class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use V1Trait;
@@ -32,6 +33,11 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
         $code = $buffer->getUint16();
         $stream = $buffer->gatString();
         return new self($code, $stream);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['code'], $data['stream']);
     }
 
     static public function getKey(): int

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
-class OpenResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class OpenResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,17 @@ class OpenResponseV1 implements KeyVersionInterface, CorrelationInterface, FromS
     public function __construct(KeyValue ...$connectionProperties)
     {
         $this->connectionProperties = $connectionProperties;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $properties = array_map(
+            fn(array $p) => new KeyValue($p['key'], $p['value']),
+            $data['connectionProperties']
+        );
+        $object = new self(...$properties);
+        $object->withCorrelationId($data['correlationId']);
+        return $object;
     }
 
     public static function fromStreamBuffer(ReadBuffer $buffer): ?object

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class PartitionsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class PartitionsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -44,6 +45,13 @@ class PartitionsResponseV1 implements KeyVersionInterface, CorrelationInterface,
         $object = new self($streams);
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self($data['streams']);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
-class PeerPropertiesResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class PeerPropertiesResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -33,6 +34,17 @@ class PeerPropertiesResponseV1 implements KeyVersionInterface, CorrelationInterf
     public static function getKey(): int
     {
         return KeyEnum::PEER_PROPERTIES_RESPONSE->value;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $properties = array_map(
+            fn(array $p) => new KeyValue($p['key'], $p['value']),
+            $data['properties']
+        );
+        $object = new self(...$properties);
+        $object->withCorrelationId($data['correlationId']);
+        return $object;
     }
 
     public static function fromStreamBuffer(ReadBuffer $buffer): ?object

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -9,7 +10,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
+class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use V1Trait;
@@ -41,6 +42,11 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
             $publishingIds[] = $buffer->getUint64();
         }
         return new self($publisherId, ...$publishingIds);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['publisherId'], ...$data['publishingIds']);
     }
 
     static public function getKey(): int

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -10,7 +11,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\PublishingError;
 
-class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
+class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
     use V1Trait;
@@ -42,6 +43,12 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
             $errors[] = PublishingError::fromStreamBuffer($buffer);
         }
         return new self($publisherId, ...$errors);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $errors = array_map(fn(array $e) => new PublishingError($e['publishingId'], $e['code']), $data['errors']);
+        return new self($data['publisherId'], ...$errors);
     }
 
     static public function getKey(): int

--- a/src/Response/QueryOffsetResponseV1.php
+++ b/src/Response/QueryOffsetResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class QueryOffsetResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class QueryOffsetResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -35,6 +36,14 @@ class QueryOffsetResponseV1 implements KeyVersionInterface, CorrelationInterface
     static public function getKey(): int
     {
         return KeyEnum::QUERY_OFFSET_RESPONSE->value;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
+        $object->offset = $data['offset'];
+        return $object;
     }
 
     public function getOffset(): int

--- a/src/Response/QueryPublisherSequenceResponseV1.php
+++ b/src/Response/QueryPublisherSequenceResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class QueryPublisherSequenceResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class QueryPublisherSequenceResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -35,6 +36,14 @@ class QueryPublisherSequenceResponseV1 implements KeyVersionInterface, Correlati
     static public function getKey(): int
     {
         return KeyEnum::QUERY_PUBLISHER_SEQUENCE_RESPONSE->value;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
+        $object->sequence = $data['sequence'];
+        return $object;
     }
 
     public function getSequence(): int

--- a/src/Response/ResolveOffsetSpecResponseV1.php
+++ b/src/Response/ResolveOffsetSpecResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class ResolveOffsetSpecResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class ResolveOffsetSpecResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -36,6 +37,14 @@ class ResolveOffsetSpecResponseV1 implements KeyVersionInterface, CorrelationInt
     static public function getKey(): int
     {
         return KeyEnum::RESOLVE_OFFSET_SPEC_RESPONSE->value;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
+        $object->offset = $data['offset'];
+        return $object;
     }
 
     public function getOffset(): int

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class RouteResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class RouteResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -44,6 +45,13 @@ class RouteResponseV1 implements KeyVersionInterface, CorrelationInterface, From
         $object = new self($streams);
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self($data['streams']);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class SaslAuthenticateResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class SaslAuthenticateResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -28,6 +29,13 @@ class SaslAuthenticateResponseV1 implements KeyVersionInterface, CorrelationInte
         $object = new self();
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class SaslHandshakeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class SaslHandshakeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -22,6 +23,13 @@ class SaslHandshakeResponseV1 implements KeyVersionInterface, CorrelationInterfa
     public function __construct(array $mechanisms)
     {
         $this->mechanisms = $mechanisms;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self($data['mechanisms']);
+        $object->withCorrelationId($data['correlationId']);
+        return $object;
     }
 
     public static function getKey(): int

--- a/src/Response/StreamStatsResponseV1.php
+++ b/src/Response/StreamStatsResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -12,7 +13,7 @@ use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\Statistic;
 
-class StreamStatsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class StreamStatsResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -49,6 +50,14 @@ class StreamStatsResponseV1 implements KeyVersionInterface, CorrelationInterface
         $object = new self($stats);
         $object->withCorrelationId($correlationId);
 
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $stats = array_map(fn(array $s) => new Statistic($s['key'], $s['value']), $data['stats']);
+        $object = new self($stats);
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/SubscribeResponseV1.php
+++ b/src/Response/SubscribeResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class SubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class SubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class SubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface, 
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/Response/TuneResponseV1.php
+++ b/src/Response/TuneResponseV1.php
@@ -2,12 +2,13 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 
-class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface
+class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, FromArrayInterface
 {
     public function __construct(private int $frameMax = 0, private int $heartbeat = 0)
     {
@@ -21,6 +22,11 @@ class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface
     static public function getKey(): int
     {
         return KeyEnum::TUNE_RESPONSE->value;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['frameMax'], $data['heartbeat']);
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Response/UnsubscribeResponseV1.php
+++ b/src/Response/UnsubscribeResponseV1.php
@@ -2,6 +2,7 @@
 
 namespace CrazyGoat\RabbitStream\Response;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
@@ -11,7 +12,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
-class UnsubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface
+class UnsubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CorrelationTrait;
     use CommandTrait;
@@ -24,6 +25,13 @@ class UnsubscribeResponseV1 implements KeyVersionInterface, CorrelationInterface
         self::isResponseCodeOk($buffer->getUint16());
         $object = new self();
         $object->withCorrelationId($correlationId);
+        return $object;
+    }
+
+    public static function fromArray(array $data): static
+    {
+        $object = new self();
+        $object->withCorrelationId($data['correlationId']);
         return $object;
     }
 

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -2,10 +2,12 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
-class Broker implements FromStreamBufferInterface
+class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
         private int $reference,
@@ -35,5 +37,19 @@ class Broker implements FromStreamBufferInterface
             $buffer->gatString(),
             $buffer->getUint32()
         );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'reference' => $this->reference,
+            'host' => $this->host,
+            'port' => $this->port,
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['reference'], $data['host'], $data['port']);
     }
 }

--- a/src/VO/CommandVersion.php
+++ b/src/VO/CommandVersion.php
@@ -2,12 +2,14 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterface
+class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
         private int $key,
@@ -45,5 +47,19 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
             ->addUInt16($this->key)
             ->addUInt16($this->minVersion)
             ->addUInt16($this->maxVersion);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'key' => $this->key,
+            'minVersion' => $this->minVersion,
+            'maxVersion' => $this->maxVersion,
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['key'], $data['minVersion'], $data['maxVersion']);
     }
 }

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -3,12 +3,14 @@
 namespace CrazyGoat\RabbitStream\VO;
 
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface
+class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(private string $key, private ?string $value)
     {
@@ -34,5 +36,15 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface
     public static function fromStreamBuffer(ReadBuffer $buffer): ?object
     {
         return new self($buffer->gatString(), $buffer->gatString());
+    }
+
+    public function toArray(): array
+    {
+        return ['key' => $this->key, 'value' => $this->value];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['key'], $data['value']);
     }
 }

--- a/src/VO/OffsetSpec.php
+++ b/src/VO/OffsetSpec.php
@@ -2,10 +2,11 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class OffsetSpec implements ToStreamBufferInterface
+class OffsetSpec implements ToStreamBufferInterface, ToArrayInterface
 {
     public const TYPE_FIRST = 0x0001;
     public const TYPE_LAST = 0x0002;
@@ -73,5 +74,10 @@ class OffsetSpec implements ToStreamBufferInterface
     public function getValue(): ?int
     {
         return $this->value;
+    }
+
+    public function toArray(): array
+    {
+        return ['type' => $this->type, 'value' => $this->value];
     }
 }

--- a/src/VO/PublishedMessage.php
+++ b/src/VO/PublishedMessage.php
@@ -2,10 +2,11 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class PublishedMessage implements ToStreamBufferInterface
+class PublishedMessage implements ToStreamBufferInterface, ToArrayInterface
 {
     public function __construct(
         private int $publishingId,
@@ -22,5 +23,10 @@ class PublishedMessage implements ToStreamBufferInterface
     public function getPublishingId(): int
     {
         return $this->publishingId;
+    }
+
+    public function toArray(): array
+    {
+        return ['publishingId' => $this->publishingId, 'data' => $this->message];
     }
 }

--- a/src/VO/PublishedMessageV2.php
+++ b/src/VO/PublishedMessageV2.php
@@ -2,10 +2,11 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class PublishedMessageV2 implements ToStreamBufferInterface
+class PublishedMessageV2 implements ToStreamBufferInterface, ToArrayInterface
 {
     public function __construct(
         private int $publishingId,
@@ -24,5 +25,14 @@ class PublishedMessageV2 implements ToStreamBufferInterface
     public function getPublishingId(): int
     {
         return $this->publishingId;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'publishingId' => $this->publishingId,
+            'filterValue' => $this->filterValue,
+            'data' => $this->message,
+        ];
     }
 }

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -2,9 +2,11 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
-class PublishingError
+class PublishingError implements ToArrayInterface, FromArrayInterface
 {
     public function __construct(
         private int $publishingId,
@@ -24,5 +26,15 @@ class PublishingError
     public static function fromStreamBuffer(ReadBuffer $buffer): self
     {
         return new self($buffer->getUint64(), $buffer->getUint16());
+    }
+
+    public function toArray(): array
+    {
+        return ['publishingId' => $this->publishingId, 'code' => $this->code];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['publishingId'], $data['code']);
     }
 }

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -2,12 +2,14 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
-class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface
+class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(private string $key, private int $value)
     {
@@ -33,5 +35,15 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface
     public static function fromStreamBuffer(ReadBuffer $buffer): ?object
     {
         return new self($buffer->gatString(), $buffer->getInt64());
+    }
+
+    public function toArray(): array
+    {
+        return ['key' => $this->key, 'value' => $this->value];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['key'], $data['value']);
     }
 }

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -2,10 +2,12 @@
 
 namespace CrazyGoat\RabbitStream\VO;
 
+use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
-class StreamMetadata implements FromStreamBufferInterface
+class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
         private string $streamName,
@@ -47,5 +49,20 @@ class StreamMetadata implements FromStreamBufferInterface
         }
 
         return new self($streamName, $responseCode, $leaderReference, $replicasReferences);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'stream' => $this->streamName,
+            'responseCode' => $this->responseCode,
+            'leaderReference' => $this->leaderReference,
+            'replicasReferences' => $this->replicasReferences,
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self($data['stream'], $data['responseCode'], $data['leaderReference'], $data['replicasReferences']);
     }
 }

--- a/tests/Request/ToArrayTest.php
+++ b/tests/Request/ToArrayTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Request;
+
+use CrazyGoat\RabbitStream\Request\CloseRequestV1;
+use CrazyGoat\RabbitStream\Request\ConsumerUpdateReplyV1;
+use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\CreditRequestV1;
+use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeletePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\ExchangeCommandVersionsRequestV1;
+use CrazyGoat\RabbitStream\Request\HeartbeatRequestV1;
+use CrazyGoat\RabbitStream\Request\MetadataRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PartitionsRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\PublishRequestV1;
+use CrazyGoat\RabbitStream\Request\PublishRequestV2;
+use CrazyGoat\RabbitStream\Request\QueryOffsetRequestV1;
+use CrazyGoat\RabbitStream\Request\QueryPublisherSequenceRequestV1;
+use CrazyGoat\RabbitStream\Request\ResolveOffsetSpecRequestV1;
+use CrazyGoat\RabbitStream\Request\RouteRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
+use CrazyGoat\RabbitStream\Request\StreamStatsRequestV1;
+use CrazyGoat\RabbitStream\Request\SubscribeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Request\UnsubscribeRequestV1;
+use CrazyGoat\RabbitStream\VO\CommandVersion;
+use CrazyGoat\RabbitStream\VO\KeyValue;
+use CrazyGoat\RabbitStream\VO\OffsetSpec;
+use CrazyGoat\RabbitStream\VO\PublishedMessage;
+use CrazyGoat\RabbitStream\VO\PublishedMessageV2;
+use PHPUnit\Framework\TestCase;
+
+class ToArrayTest extends TestCase
+{
+    public function testSaslHandshakeRequestReturnsEmptyArray(): void
+    {
+        $request = new SaslHandshakeRequestV1();
+        $this->assertSame([], $request->toArray());
+    }
+
+    public function testHeartbeatRequestReturnsEmptyArray(): void
+    {
+        $request = new HeartbeatRequestV1();
+        $this->assertSame([], $request->toArray());
+    }
+
+    public function testOpenRequestReturnsVhost(): void
+    {
+        $request = new OpenRequest('/my-vhost');
+        $this->assertSame(['vhost' => '/my-vhost'], $request->toArray());
+    }
+
+    public function testDeleteStreamRequestReturnsStream(): void
+    {
+        $request = new DeleteStreamRequestV1('my-stream');
+        $this->assertSame(['stream' => 'my-stream'], $request->toArray());
+    }
+
+    public function testDeletePublisherRequestReturnsPublisherId(): void
+    {
+        $request = new DeletePublisherRequestV1(5);
+        $this->assertSame(['publisherId' => 5], $request->toArray());
+    }
+
+    public function testUnsubscribeRequestReturnsSubscriptionId(): void
+    {
+        $request = new UnsubscribeRequestV1(3);
+        $this->assertSame(['subscriptionId' => 3], $request->toArray());
+    }
+
+    public function testStreamStatsRequestReturnsStream(): void
+    {
+        $request = new StreamStatsRequestV1('stats-stream');
+        $this->assertSame(['stream' => 'stats-stream'], $request->toArray());
+    }
+
+    public function testPartitionsRequestReturnsSuperStream(): void
+    {
+        $request = new PartitionsRequestV1('my-super-stream');
+        $this->assertSame(['superStream' => 'my-super-stream'], $request->toArray());
+    }
+
+    public function testDeleteSuperStreamRequestReturnsName(): void
+    {
+        $request = new DeleteSuperStreamRequestV1('super-stream-name');
+        $this->assertSame(['name' => 'super-stream-name'], $request->toArray());
+    }
+
+    public function testSaslAuthenticateRequestReturnsCredentials(): void
+    {
+        $request = new SaslAuthenticateRequestV1('PLAIN', 'user', 'pass');
+        $this->assertSame([
+            'mechanism' => 'PLAIN',
+            'username' => 'user',
+            'password' => 'pass',
+        ], $request->toArray());
+    }
+
+    public function testTuneRequestReturnsFrameMaxAndHeartbeat(): void
+    {
+        $request = new TuneRequestV1(131072, 60);
+        $this->assertSame(['frameMax' => 131072, 'heartbeat' => 60], $request->toArray());
+    }
+
+    public function testCloseRequestReturnsCodeAndReason(): void
+    {
+        $request = new CloseRequestV1(1, 'normal shutdown');
+        $this->assertSame([
+            'closingCode' => 1,
+            'closingReason' => 'normal shutdown',
+        ], $request->toArray());
+    }
+
+    public function testDeclarePublisherRequestReturnsAllFields(): void
+    {
+        $request = new DeclarePublisherRequestV1(1, 'my-ref', 'my-stream');
+        $this->assertSame([
+            'publisherId' => 1,
+            'publisherReference' => 'my-ref',
+            'stream' => 'my-stream',
+        ], $request->toArray());
+    }
+
+    public function testDeclarePublisherRequestWithNullReference(): void
+    {
+        $request = new DeclarePublisherRequestV1(2, null, 'stream');
+        $this->assertSame([
+            'publisherId' => 2,
+            'publisherReference' => null,
+            'stream' => 'stream',
+        ], $request->toArray());
+    }
+
+    public function testCreditRequestReturnsSubscriptionIdAndCredit(): void
+    {
+        $request = new CreditRequestV1(7, 100);
+        $this->assertSame(['subscriptionId' => 7, 'credit' => 100], $request->toArray());
+    }
+
+    public function testStoreOffsetRequestReturnsAllFields(): void
+    {
+        $request = new StoreOffsetRequestV1('ref', 'stream', 42);
+        $this->assertSame([
+            'reference' => 'ref',
+            'stream' => 'stream',
+            'offset' => 42,
+        ], $request->toArray());
+    }
+
+    public function testQueryOffsetRequestReturnsReferenceAndStream(): void
+    {
+        $request = new QueryOffsetRequestV1('ref', 'stream');
+        $this->assertSame(['reference' => 'ref', 'stream' => 'stream'], $request->toArray());
+    }
+
+    public function testQueryPublisherSequenceRequestReturnsReferenceAndStream(): void
+    {
+        $request = new QueryPublisherSequenceRequestV1('ref', 'stream');
+        $this->assertSame(['reference' => 'ref', 'stream' => 'stream'], $request->toArray());
+    }
+
+    public function testRouteRequestReturnsRoutingKeyAndSuperStream(): void
+    {
+        $request = new RouteRequestV1('key', 'super');
+        $this->assertSame(['routingKey' => 'key', 'superStream' => 'super'], $request->toArray());
+    }
+
+    public function testResolveOffsetSpecRequestReturnsStreamAndOffsetSpec(): void
+    {
+        $request = new ResolveOffsetSpecRequestV1('stream', OffsetSpec::first());
+        $array = $request->toArray();
+        $this->assertSame('stream', $array['stream']);
+        $this->assertSame(['type' => OffsetSpec::TYPE_FIRST, 'value' => null], $array['offsetSpec']);
+    }
+
+    public function testPeerPropertiesRequestReturnsProperties(): void
+    {
+        $request = new PeerPropertiesToStreamBufferV1(
+            new KeyValue('product', 'test'),
+            new KeyValue('version', '1.0')
+        );
+        $this->assertSame([
+            'properties' => [
+                ['key' => 'product', 'value' => 'test'],
+                ['key' => 'version', 'value' => '1.0'],
+            ],
+        ], $request->toArray());
+    }
+
+    public function testCreateRequestReturnsStreamAndArguments(): void
+    {
+        $request = new CreateRequestV1('my-stream', ['max-length-bytes' => '1000000']);
+        $this->assertSame([
+            'stream' => 'my-stream',
+            'arguments' => ['max-length-bytes' => '1000000'],
+        ], $request->toArray());
+    }
+
+    public function testMetadataRequestReturnsStreams(): void
+    {
+        $request = new MetadataRequestV1(['stream1', 'stream2']);
+        $this->assertSame(['streams' => ['stream1', 'stream2']], $request->toArray());
+    }
+
+    public function testPublishRequestV1ReturnsPublisherIdAndMessages(): void
+    {
+        $msg = new PublishedMessage(1, 'hello');
+        $request = new PublishRequestV1(3, $msg);
+        $array = $request->toArray();
+        $this->assertSame(3, $array['publisherId']);
+        $this->assertSame([['publishingId' => 1, 'data' => 'hello']], $array['messages']);
+    }
+
+    public function testPublishRequestV2ReturnsPublisherIdAndMessages(): void
+    {
+        $msg = new PublishedMessageV2(1, 'filter-val', 'hello');
+        $request = new PublishRequestV2(4, $msg);
+        $array = $request->toArray();
+        $this->assertSame(4, $array['publisherId']);
+        $this->assertSame([[
+            'publishingId' => 1,
+            'filterValue' => 'filter-val',
+            'data' => 'hello',
+        ]], $array['messages']);
+    }
+
+    public function testSubscribeRequestReturnsAllFields(): void
+    {
+        $request = new SubscribeRequestV1(1, 'stream', OffsetSpec::offset(100), 10);
+        $array = $request->toArray();
+        $this->assertSame(1, $array['subscriptionId']);
+        $this->assertSame('stream', $array['stream']);
+        $this->assertSame(['type' => OffsetSpec::TYPE_OFFSET, 'value' => 100], $array['offsetSpec']);
+        $this->assertSame(10, $array['credit']);
+    }
+
+    public function testExchangeCommandVersionsRequestReturnsCommands(): void
+    {
+        $cv = new CommandVersion(1, 1, 1);
+        $request = new ExchangeCommandVersionsRequestV1([$cv]);
+        $this->assertSame([
+            'commands' => [['key' => 1, 'minVersion' => 1, 'maxVersion' => 1]],
+        ], $request->toArray());
+    }
+
+    public function testCreateSuperStreamRequestReturnsAllFields(): void
+    {
+        $request = new CreateSuperStreamRequestV1('super', ['p1', 'p2'], ['k1', 'k2'], ['arg' => 'val']);
+        $this->assertSame([
+            'name' => 'super',
+            'partitions' => ['p1', 'p2'],
+            'bindingKeys' => ['k1', 'k2'],
+            'arguments' => ['arg' => 'val'],
+        ], $request->toArray());
+    }
+
+    public function testConsumerUpdateReplyReturnsAllFields(): void
+    {
+        $request = new ConsumerUpdateReplyV1(10, 1, 4, 500);
+        $this->assertSame([
+            'correlationId' => 10,
+            'responseCode' => 1,
+            'offsetType' => 4,
+            'offset' => 500,
+        ], $request->toArray());
+    }
+}

--- a/tests/Response/FromArrayTest.php
+++ b/tests/Response/FromArrayTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Response;
+
+use CrazyGoat\RabbitStream\Response\CloseResponseV1;
+use CrazyGoat\RabbitStream\Response\ConsumerUpdateQueryV1;
+use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\CreditResponseV1;
+use CrazyGoat\RabbitStream\Response\DeclarePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\DeletePublisherResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteSuperStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\DeliverResponseV1;
+use CrazyGoat\RabbitStream\Response\ExchangeCommandVersionsResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataUpdateResponseV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Response\PartitionsResponseV1;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishConfirmResponseV1;
+use CrazyGoat\RabbitStream\Response\PublishErrorResponseV1;
+use CrazyGoat\RabbitStream\Response\QueryOffsetResponseV1;
+use CrazyGoat\RabbitStream\Response\QueryPublisherSequenceResponseV1;
+use CrazyGoat\RabbitStream\Response\ResolveOffsetSpecResponseV1;
+use CrazyGoat\RabbitStream\Response\RouteResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Response\StreamStatsResponseV1;
+use CrazyGoat\RabbitStream\Response\SubscribeResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\Response\UnsubscribeResponseV1;
+use PHPUnit\Framework\TestCase;
+
+class FromArrayTest extends TestCase
+{
+    public function testSaslAuthenticateResponseFromArray(): void
+    {
+        $response = SaslAuthenticateResponseV1::fromArray(['correlationId' => 5]);
+        $this->assertInstanceOf(SaslAuthenticateResponseV1::class, $response);
+        $this->assertSame(5, $response->getCorrelationId());
+    }
+
+    public function testCloseResponseFromArray(): void
+    {
+        $response = CloseResponseV1::fromArray(['correlationId' => 10]);
+        $this->assertSame(10, $response->getCorrelationId());
+    }
+
+    public function testCreateResponseFromArray(): void
+    {
+        $response = CreateResponseV1::fromArray(['correlationId' => 1]);
+        $this->assertSame(1, $response->getCorrelationId());
+    }
+
+    public function testDeleteStreamResponseFromArray(): void
+    {
+        $response = DeleteStreamResponseV1::fromArray(['correlationId' => 2]);
+        $this->assertSame(2, $response->getCorrelationId());
+    }
+
+    public function testDeclarePublisherResponseFromArray(): void
+    {
+        $response = DeclarePublisherResponseV1::fromArray(['correlationId' => 3]);
+        $this->assertSame(3, $response->getCorrelationId());
+    }
+
+    public function testDeletePublisherResponseFromArray(): void
+    {
+        $response = DeletePublisherResponseV1::fromArray(['correlationId' => 4]);
+        $this->assertSame(4, $response->getCorrelationId());
+    }
+
+    public function testSubscribeResponseFromArray(): void
+    {
+        $response = SubscribeResponseV1::fromArray(['correlationId' => 6]);
+        $this->assertSame(6, $response->getCorrelationId());
+    }
+
+    public function testUnsubscribeResponseFromArray(): void
+    {
+        $response = UnsubscribeResponseV1::fromArray(['correlationId' => 7]);
+        $this->assertSame(7, $response->getCorrelationId());
+    }
+
+    public function testCreateSuperStreamResponseFromArray(): void
+    {
+        $response = CreateSuperStreamResponseV1::fromArray(['correlationId' => 8]);
+        $this->assertSame(8, $response->getCorrelationId());
+    }
+
+    public function testDeleteSuperStreamResponseFromArray(): void
+    {
+        $response = DeleteSuperStreamResponseV1::fromArray(['correlationId' => 9]);
+        $this->assertSame(9, $response->getCorrelationId());
+    }
+
+    public function testSaslHandshakeResponseFromArray(): void
+    {
+        $response = SaslHandshakeResponseV1::fromArray([
+            'correlationId' => 1,
+            'mechanisms' => ['PLAIN', 'AMQPLAIN'],
+        ]);
+        $this->assertSame(1, $response->getCorrelationId());
+    }
+
+    public function testOpenResponseFromArray(): void
+    {
+        $response = OpenResponseV1::fromArray([
+            'correlationId' => 2,
+            'connectionProperties' => [
+                ['key' => 'product', 'value' => 'RabbitMQ'],
+            ],
+        ]);
+        $this->assertSame(2, $response->getCorrelationId());
+        $this->assertInstanceOf(OpenResponseV1::class, $response);
+    }
+
+    public function testPeerPropertiesResponseFromArray(): void
+    {
+        $response = PeerPropertiesResponseV1::fromArray([
+            'correlationId' => 3,
+            'properties' => [
+                ['key' => 'product', 'value' => 'RabbitMQ'],
+                ['key' => 'version', 'value' => '3.12'],
+            ],
+        ]);
+        $this->assertSame(3, $response->getCorrelationId());
+        $this->assertCount(2, $response->getPeerProperty());
+    }
+
+    public function testQueryOffsetResponseFromArray(): void
+    {
+        $response = QueryOffsetResponseV1::fromArray(['correlationId' => 4, 'offset' => 12345]);
+        $this->assertSame(4, $response->getCorrelationId());
+        $this->assertSame(12345, $response->getOffset());
+    }
+
+    public function testQueryPublisherSequenceResponseFromArray(): void
+    {
+        $response = QueryPublisherSequenceResponseV1::fromArray(['correlationId' => 5, 'sequence' => 99]);
+        $this->assertSame(5, $response->getCorrelationId());
+        $this->assertSame(99, $response->getSequence());
+    }
+
+    public function testStreamStatsResponseFromArray(): void
+    {
+        $response = StreamStatsResponseV1::fromArray([
+            'correlationId' => 6,
+            'stats' => [['key' => 'messages', 'value' => 1000]],
+        ]);
+        $this->assertSame(6, $response->getCorrelationId());
+        $this->assertCount(1, $response->getStats());
+        $this->assertSame('messages', $response->getStats()[0]->getKey());
+        $this->assertSame(1000, $response->getStats()[0]->getValue());
+    }
+
+    public function testMetadataResponseFromArray(): void
+    {
+        $response = MetadataResponseV1::fromArray([
+            'correlationId' => 7,
+            'brokers' => [['reference' => 1, 'host' => 'localhost', 'port' => 5672]],
+            'streamMetadata' => [['stream' => 'my-stream', 'responseCode' => 1, 'leaderReference' => 1, 'replicasReferences' => []]],
+        ]);
+        $this->assertSame(7, $response->getCorrelationId());
+        $this->assertCount(1, $response->getBrokers());
+        $this->assertCount(1, $response->getStreamMetadata());
+    }
+
+    public function testExchangeCommandVersionsResponseFromArray(): void
+    {
+        $response = ExchangeCommandVersionsResponseV1::fromArray([
+            'correlationId' => 8,
+            'commands' => [['key' => 1, 'minVersion' => 1, 'maxVersion' => 2]],
+        ]);
+        $this->assertSame(8, $response->getCorrelationId());
+        $this->assertCount(1, $response->getCommands());
+        $this->assertSame(1, $response->getCommands()[0]->getKey());
+    }
+
+    public function testRouteResponseFromArray(): void
+    {
+        $response = RouteResponseV1::fromArray([
+            'correlationId' => 9,
+            'streams' => ['stream1', 'stream2'],
+        ]);
+        $this->assertSame(9, $response->getCorrelationId());
+        $this->assertSame(['stream1', 'stream2'], $response->getStreams());
+    }
+
+    public function testPartitionsResponseFromArray(): void
+    {
+        $response = PartitionsResponseV1::fromArray([
+            'correlationId' => 10,
+            'streams' => ['partition-0', 'partition-1'],
+        ]);
+        $this->assertSame(10, $response->getCorrelationId());
+        $this->assertSame(['partition-0', 'partition-1'], $response->getStreams());
+    }
+
+    public function testResolveOffsetSpecResponseFromArray(): void
+    {
+        $response = ResolveOffsetSpecResponseV1::fromArray(['correlationId' => 11, 'offset' => 500]);
+        $this->assertSame(11, $response->getCorrelationId());
+        $this->assertSame(500, $response->getOffset());
+    }
+
+    public function testPublishConfirmResponseFromArray(): void
+    {
+        $response = PublishConfirmResponseV1::fromArray([
+            'publisherId' => 1,
+            'publishingIds' => [10, 11, 12],
+        ]);
+        $this->assertSame(1, $response->getPublisherId());
+        $this->assertSame([10, 11, 12], $response->getPublishingIds());
+    }
+
+    public function testPublishErrorResponseFromArray(): void
+    {
+        $response = PublishErrorResponseV1::fromArray([
+            'publisherId' => 2,
+            'errors' => [['publishingId' => 5, 'code' => 2]],
+        ]);
+        $this->assertSame(2, $response->getPublisherId());
+        $this->assertCount(1, $response->getErrors());
+        $this->assertSame(5, $response->getErrors()[0]->getPublishingId());
+        $this->assertSame(2, $response->getErrors()[0]->getCode());
+    }
+
+    public function testDeliverResponseFromArray(): void
+    {
+        $response = DeliverResponseV1::fromArray(['subscriptionId' => 3, 'chunkBytes' => 'raw-bytes']);
+        $this->assertSame(3, $response->getSubscriptionId());
+        $this->assertSame('raw-bytes', $response->getChunkBytes());
+    }
+
+    public function testMetadataUpdateResponseFromArray(): void
+    {
+        $response = MetadataUpdateResponseV1::fromArray(['code' => 1, 'stream' => 'my-stream']);
+        $this->assertSame(1, $response->getCode());
+        $this->assertSame('my-stream', $response->getStream());
+    }
+
+    public function testCreditResponseFromArray(): void
+    {
+        $response = CreditResponseV1::fromArray(['responseCode' => 1, 'subscriptionId' => 5]);
+        $this->assertSame(1, $response->getResponseCode());
+        $this->assertSame(5, $response->getSubscriptionId());
+    }
+
+    public function testConsumerUpdateQueryFromArray(): void
+    {
+        $response = ConsumerUpdateQueryV1::fromArray([
+            'correlationId' => 12,
+            'subscriptionId' => 3,
+            'active' => true,
+        ]);
+        $this->assertSame(12, $response->getCorrelationId());
+        $this->assertSame(3, $response->getSubscriptionId());
+        $this->assertTrue($response->isActive());
+    }
+
+    public function testTuneResponseFromArray(): void
+    {
+        $response = TuneResponseV1::fromArray(['frameMax' => 131072, 'heartbeat' => 60]);
+        $this->assertInstanceOf(TuneResponseV1::class, $response);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ToArrayInterface` and `FromArrayInterface` to `src/Buffer/`
- Add `toArray()` to all 28 Request classes and 9 VO classes
- Add `fromArray()` to all 28 Response classes and 6 VO classes

## Why

Foundation for swappable serialization backends (iteration 1 of #57). Once Request/Response speak in arrays, C++ FFI or PHP extension backends can convert `array ↔ binary` without touching protocol logic.

## Tests

- 57 new roundtrip tests added
- 188 unit tests pass
- 43 E2E tests pass

Closes #47