### PR TITLE
feat: implement Connection class as high-level entry point (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,35 @@ composer require crazy-goat/rabbit-stream
 ### High-level API (Recommended)
 
 ```php
-use CrazyGoat\RabbitStream\Client\StreamClient;
-use CrazyGoat\RabbitStream\Client\StreamClientConfig;
-use CrazyGoat\RabbitStream\Client\ProducerConfig;
+use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 
 // Connect (handshake and authentication handled automatically)
-$client = StreamClient::connect(new StreamClientConfig(
+$connection = Connection::create(
     host: '127.0.0.1',
     user: 'guest',
     password: 'guest'
-));
+);
 
 // Create a producer for 'my-stream'
-$producer = $client->createProducer('my-stream', new ProducerConfig(
-    onConfirmation: function (ConfirmationStatus $status): void {
+$producer = $connection->createProducer(
+    stream: 'my-stream',
+    onConfirm: function (ConfirmationStatus $status): void {
         if ($status->isConfirmed()) {
             echo "Message {$status->getPublishingId()} confirmed\n";
         }
     }
-));
+);
 
 // Send a message
 $producer->send("Hello, RabbitMQ Stream!");
 
 // Drive the loop to receive confirmations (optional, blocking)
-$client->readLoop(maxFrames: 1);
+$connection->readLoop(maxFrames: 1);
 
 // Close producer and connection
 $producer->close();
-$client->close();
+$connection->close();
 ```
 
 ### Consuming with Message Decoding

--- a/examples/simple_publisher.php
+++ b/examples/simple_publisher.php
@@ -1,9 +1,7 @@
 <?php
 
+use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
-use CrazyGoat\RabbitStream\Client\ProducerConfig;
-use CrazyGoat\RabbitStream\Client\StreamClient;
-use CrazyGoat\RabbitStream\Client\StreamClientConfig;
 
 include __DIR__ . '/../vendor/autoload.php';
 
@@ -13,32 +11,36 @@ $port = (int)(getenv('RABBITMQ_PORT') ?: 5552);
 echo "Connecting to RabbitMQ Stream at $host:$port...\n";
 
 try {
-    $client = StreamClient::connect(new StreamClientConfig(
+    $connection = Connection::create(
         host: $host,
         port: $port,
-    ));
+        user: 'guest',
+        password: 'guest',
+        vhost: '/'
+    );
 
     echo "Connected successfully.\n";
 
-    $producer = $client->createProducer('test-stream', new ProducerConfig(
-        onConfirmation: function (ConfirmationStatus $status): void {
+    $producer = $connection->createProducer(
+        stream: 'test-stream',
+        onConfirm: function (ConfirmationStatus $status): void {
             if ($status->isConfirmed()) {
                 echo "Message confirmed! ID: {$status->getPublishingId()}\n";
             } else {
                 echo "Message failed! ID: {$status->getPublishingId()}, Error: {$status->getErrorCode()}\n";
             }
         }
-    ));
+    );
 
     echo "Sending message...\n";
     $producer->send("Hello, RabbitStream!");
 
     echo "Waiting for confirmation...\n";
-    $client->readLoop(maxFrames: 1);
+    $connection->readLoop(maxFrames: 1);
 
     echo "Closing...\n";
     $producer->close();
-    $client->close();
+    $connection->close();
 
     echo "Done.\n";
 } catch (\Exception $e) {

--- a/examples/store_offset.php
+++ b/examples/store_offset.php
@@ -1,8 +1,6 @@
 <?php
 
-use CrazyGoat\RabbitStream\Client\StreamClient;
-use CrazyGoat\RabbitStream\Client\StreamClientConfig;
-use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
+use CrazyGoat\RabbitStream\Client\Connection;
 
 include __DIR__ . '/../vendor/autoload.php';
 
@@ -12,27 +10,41 @@ $port = (int)(getenv('RABBITMQ_PORT') ?: 5552);
 echo "Connecting to RabbitMQ Stream at $host:$port...\n";
 
 try {
-    $client = StreamClient::connect(new StreamClientConfig(
+    $connection = Connection::create(
         host: $host,
         port: $port,
-    ));
+        user: 'guest',
+        password: 'guest',
+        vhost: '/'
+    );
 
     echo "Connected successfully.\n";
 
+    // Ensure stream exists
+    if (!$connection->streamExists('test-stream')) {
+        echo "Creating stream 'test-stream'...\n";
+        $connection->createStream('test-stream');
+    }
+
     // Store an offset for a consumer reference
     // This allows resuming consumption from a known position
-    $request = new StoreOffsetRequestV1(
+    echo "Storing offset...\n";
+    $connection->storeOffset(
         reference: 'my-consumer-ref',
         stream: 'test-stream',
         offset: 100
     );
 
-    echo "Storing offset...\n";
-    $client->sendMessage($request);
-
     echo "Offset stored successfully.\n";
 
-    $client->close();
+    // Query the offset back to verify
+    $offset = $connection->queryOffset(
+        reference: 'my-consumer-ref',
+        stream: 'test-stream'
+    );
+    echo "Retrieved offset: $offset\n";
+
+    $connection->close();
     echo "Done.\n";
 } catch (\Exception $e) {
     echo "Error: " . $e->getMessage() . "\n";

--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Client;
+
+use CrazyGoat\RabbitStream\Enum\ResponseCodeEnum;
+use CrazyGoat\RabbitStream\Request\CloseRequestV1;
+use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\MetadataRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequest;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
+use CrazyGoat\RabbitStream\Request\QueryOffsetRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
+use CrazyGoat\RabbitStream\Request\StreamStatsRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\CloseResponseV1;
+use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
+use CrazyGoat\RabbitStream\Response\QueryOffsetResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Response\StreamStatsResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\Serializer\BinarySerializerInterface;
+use CrazyGoat\RabbitStream\Serializer\PhpBinarySerializer;
+use CrazyGoat\RabbitStream\StreamConnection;
+use CrazyGoat\RabbitStream\VO\OffsetSpec;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class Connection
+{
+    private int $publisherIdCounter = 0;
+    private int $subscriptionIdCounter = 0;
+
+    private function __construct(
+        private readonly StreamConnection $streamConnection,
+    ) {}
+
+    static public function create(
+        string $host = '127.0.0.1',
+        int $port = 5552,
+        string $user = 'guest',
+        string $password = 'guest',
+        string $vhost = '/',
+        ?BinarySerializerInterface $serializer = null,
+        ?LoggerInterface $logger = null,
+    ): self {
+        $logger ??= new NullLogger();
+        $serializer ??= new PhpBinarySerializer();
+
+        $streamConnection = new StreamConnection($host, $port, $logger, $serializer);
+        $streamConnection->connect();
+
+        // 1. PeerProperties
+        $streamConnection->sendMessage(new PeerPropertiesToStreamBufferV1());
+        $streamConnection->readMessage();
+
+        // 2. SaslHandshake
+        $streamConnection->sendMessage(new SaslHandshakeRequestV1());
+        $handshakeResponse = $streamConnection->readMessage();
+        if (!$handshakeResponse instanceof SaslHandshakeResponseV1) {
+            throw new \Exception("Expected SaslHandshakeResponseV1, got " . get_class($handshakeResponse));
+        }
+        // Verify PLAIN mechanism is available
+        $mechanisms = $handshakeResponse->getMechanisms();
+        if (!in_array('PLAIN', $mechanisms, true)) {
+            throw new \Exception("PLAIN SASL mechanism not supported by server");
+        }
+
+        // 3. SaslAuthenticate
+        $streamConnection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', $user, $password));
+        $streamConnection->readMessage();
+
+        // 4. Tune (server sends TuneRequestV1)
+        $tune = $streamConnection->readMessage();
+        if (!$tune instanceof TuneRequestV1) {
+            throw new \Exception("Expected TuneRequestV1, got " . get_class($tune));
+        }
+
+        // 5. TuneResponse (echo back server's values)
+        $streamConnection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        // 6. Open
+        $streamConnection->sendMessage(new OpenRequest($vhost));
+        $streamConnection->readMessage();
+
+        return new self($streamConnection);
+    }
+
+    public function createStream(string $name, array $arguments = []): void
+    {
+        $this->streamConnection->sendMessage(new CreateRequestV1($name, $arguments));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof CreateResponseV1) {
+            throw new \Exception("Expected CreateResponseV1, got " . get_class($response));
+        }
+    }
+
+    public function deleteStream(string $name): void
+    {
+        $this->streamConnection->sendMessage(new DeleteStreamRequestV1($name));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof DeleteStreamResponseV1) {
+            throw new \Exception("Expected DeleteStreamResponseV1, got " . get_class($response));
+        }
+    }
+
+    public function streamExists(string $name): bool
+    {
+        $this->streamConnection->sendMessage(new MetadataRequestV1([$name]));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof MetadataResponseV1) {
+            throw new \Exception("Expected MetadataResponseV1, got " . get_class($response));
+        }
+        foreach ($response->getStreamMetadata() as $meta) {
+            if ($meta->getStreamName() === $name) {
+                return $meta->getResponseCode() === ResponseCodeEnum::OK->value;
+            }
+        }
+        return false;
+    }
+
+    public function getStreamStats(string $name): array
+    {
+        $this->streamConnection->sendMessage(new StreamStatsRequestV1($name));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof StreamStatsResponseV1) {
+            throw new \Exception("Expected StreamStatsResponseV1, got " . get_class($response));
+        }
+        $result = [];
+        foreach ($response->getStats() as $stat) {
+            $result[$stat->getKey()] = $stat->getValue();
+        }
+        return $result;
+    }
+
+    public function getMetadata(array $streams): MetadataResponseV1
+    {
+        $this->streamConnection->sendMessage(new MetadataRequestV1($streams));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof MetadataResponseV1) {
+            throw new \Exception("Expected MetadataResponseV1, got " . get_class($response));
+        }
+        return $response;
+    }
+
+    public function queryOffset(string $reference, string $stream): int
+    {
+        $this->streamConnection->sendMessage(new QueryOffsetRequestV1($reference, $stream));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof QueryOffsetResponseV1) {
+            throw new \Exception("Expected QueryOffsetResponseV1, got " . get_class($response));
+        }
+        return $response->getOffset();
+    }
+
+    public function close(): void
+    {
+        try {
+            $this->streamConnection->sendMessage(new CloseRequestV1(0, 'OK'));
+            $response = $this->streamConnection->readMessage();
+            if (!$response instanceof CloseResponseV1) {
+                throw new \Exception("Expected CloseResponseV1, got " . get_class($response));
+            }
+        } finally {
+            $this->streamConnection->close();
+        }
+    }
+
+    public function createProducer(
+        string $stream,
+        ?string $name = null,
+        ?callable $onConfirm = null,
+    ): Producer {
+        $publisherId = $this->publisherIdCounter++;
+        $config = new ProducerConfig($name, $onConfirm);
+        return new Producer($this->streamConnection, $stream, $publisherId, $config);
+    }
+
+    public function createConsumer(
+        string $stream,
+        OffsetSpec $offset,
+        ?string $name = null,
+        int $autoCommit = 0,
+        int $initialCredit = 10,
+    ): Consumer {
+        $subscriptionId = $this->subscriptionIdCounter++;
+        return new Consumer($this->streamConnection, $stream, $subscriptionId, $offset, $name, $autoCommit, $initialCredit);
+    }
+
+    public function readLoop(?int $maxFrames = null): void
+    {
+        $this->streamConnection->readLoop($maxFrames);
+    }
+
+    public function storeOffset(string $reference, string $stream, int $offset): void
+    {
+        $this->streamConnection->sendMessage(new StoreOffsetRequestV1($reference, $stream, $offset));
+    }
+}

--- a/src/Client/Consumer.php
+++ b/src/Client/Consumer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Client;
+
+use CrazyGoat\RabbitStream\StreamConnection;
+use CrazyGoat\RabbitStream\VO\OffsetSpec;
+
+/**
+ * Stub Consumer class - full implementation in iteration 8
+ */
+class Consumer
+{
+    public function __construct(
+        private readonly StreamConnection $connection,
+        private readonly string $stream,
+        private readonly int $subscriptionId,
+        private readonly OffsetSpec $offset,
+        private readonly ?string $name = null,
+        private readonly int $autoCommit = 0,
+        private readonly int $initialCredit = 10,
+    ) {
+        // Stub implementation - full logic in iteration 8
+    }
+}

--- a/src/Client/Message.php
+++ b/src/Client/Message.php
@@ -7,7 +7,7 @@ class Message
     public function __construct(
         private readonly int $offset,
         private readonly int $timestamp,
-        private readonly string|int|float|array|null $body,
+        private readonly string|int|float|bool|array|null $body,
         private readonly array $properties = [],
         private readonly array $applicationProperties = [],
         private readonly array $messageAnnotations = [],
@@ -23,7 +23,7 @@ class Message
         return $this->timestamp;
     }
 
-    public function getBody(): string|int|float|array|null
+    public function getBody(): string|int|float|bool|array|null
     {
         return $this->body;
     }

--- a/src/Client/StreamClient.php
+++ b/src/Client/StreamClient.php
@@ -12,6 +12,9 @@ use CrazyGoat\RabbitStream\Response\QueryPublisherSequenceResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
 
+/**
+ * @deprecated Use Connection::create() instead
+ */
 class StreamClient
 {
     private int $publisherIdCounter = 0;

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -32,6 +32,11 @@ class SaslHandshakeResponseV1 implements KeyVersionInterface, CorrelationInterfa
         return $object;
     }
 
+    public function getMechanisms(): array
+    {
+        return $this->mechanisms;
+    }
+
     public static function getKey(): int
     {
         return KeyEnum::SASL_HANDSHAKE_RESPONSE->value;

--- a/tests/Client/ConnectionTest.php
+++ b/tests/Client/ConnectionTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\Client;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Request\CloseRequestV1;
+use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\MetadataRequestV1;
+use CrazyGoat\RabbitStream\Response\CloseResponseV1;
+use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use CrazyGoat\RabbitStream\VO\Broker;
+use CrazyGoat\RabbitStream\VO\StreamMetadata;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionTest extends TestCase
+{
+    public function testCreateStreamSendsCorrectRequest(): void
+    {
+        $streamConnection = $this->createMock(StreamConnection::class);
+        
+        $streamConnection->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->callback(function ($request) {
+                return $request instanceof CreateRequestV1 
+                    && $request->toArray()['stream'] === 'test-stream';
+            }));
+        
+        $streamConnection->expects($this->once())
+            ->method('readMessage')
+            ->willReturn(new CreateResponseV1());
+        
+        // Create Connection using reflection to inject mock
+        $connection = $this->createConnectionWithMock($streamConnection);
+        
+        $connection->createStream('test-stream');
+    }
+
+    public function testCloseSendsCloseRequestBeforeClosingSocket(): void
+    {
+        $streamConnection = $this->createMock(StreamConnection::class);
+        
+        $streamConnection->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->callback(function ($request) {
+                return $request instanceof CloseRequestV1;
+            }));
+        
+        $streamConnection->expects($this->once())
+            ->method('readMessage')
+            ->willReturn(new CloseResponseV1());
+        
+        $streamConnection->expects($this->once())
+            ->method('close');
+        
+        $connection = $this->createConnectionWithMock($streamConnection);
+        
+        $connection->close();
+    }
+
+    public function testStreamExistsReturnsTrueWhenStreamExists(): void
+    {
+        $streamConnection = $this->createMock(StreamConnection::class);
+        
+        $streamConnection->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->callback(function ($request) {
+                return $request instanceof MetadataRequestV1 
+                    && $request->toArray()['streams'] === ['existing-stream'];
+            }));
+        
+        $metadata = new MetadataResponseV1(
+            brokers: [new Broker(1, 'localhost', 5552)],
+            streamMetadata: [new StreamMetadata('existing-stream', 0x01, 1, [])]
+        );
+        
+        $streamConnection->expects($this->once())
+            ->method('readMessage')
+            ->willReturn($metadata);
+        
+        $connection = $this->createConnectionWithMock($streamConnection);
+        
+        $this->assertTrue($connection->streamExists('existing-stream'));
+    }
+
+    public function testStreamExistsReturnsFalseWhenStreamDoesNotExist(): void
+    {
+        $streamConnection = $this->createMock(StreamConnection::class);
+        
+        $streamConnection->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->callback(function ($request) {
+                return $request instanceof MetadataRequestV1 
+                    && $request->toArray()['streams'] === ['non-existing-stream'];
+            }));
+        
+        $metadata = new MetadataResponseV1(
+            brokers: [],
+            streamMetadata: [new StreamMetadata('non-existing-stream', 0x02, 0, [])] // 0x02 = STREAM_NOT_EXIST
+        );
+        
+        $streamConnection->expects($this->once())
+            ->method('readMessage')
+            ->willReturn($metadata);
+        
+        $connection = $this->createConnectionWithMock($streamConnection);
+        
+        $this->assertFalse($connection->streamExists('non-existing-stream'));
+    }
+
+    public function testDeleteStreamSendsCorrectRequest(): void
+    {
+        $streamConnection = $this->createMock(StreamConnection::class);
+        
+        $streamConnection->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->callback(function ($request) {
+                return $request instanceof DeleteStreamRequestV1 
+                    && $request->toArray()['stream'] === 'stream-to-delete';
+            }));
+        
+        $streamConnection->expects($this->once())
+            ->method('readMessage')
+            ->willReturn(new DeleteStreamResponseV1());
+        
+        $connection = $this->createConnectionWithMock($streamConnection);
+        
+        $connection->deleteStream('stream-to-delete');
+    }
+
+    private function createConnectionWithMock(StreamConnection $mock): Connection
+    {
+        $reflection = new \ReflectionClass(Connection::class);
+        $constructor = $reflection->getConstructor();
+        $constructor->setAccessible(true);
+        
+        $connection = $reflection->newInstanceWithoutConstructor();
+        $constructor->invoke($connection, $mock);
+        
+        return $connection;
+    }
+}

--- a/tests/E2E/ConnectionTest.php
+++ b/tests/E2E/ConnectionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    public function testConnectionCreateAndStreamManagement(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-connection-stream-' . uniqid();
+
+        // Create stream
+        $connection->createStream($streamName);
+
+        // Verify stream exists
+        $this->assertTrue($connection->streamExists($streamName));
+
+        // Delete stream
+        $connection->deleteStream($streamName);
+
+        // Verify stream no longer exists
+        $this->assertFalse($connection->streamExists($streamName));
+
+        // Close connection gracefully
+        $connection->close();
+    }
+
+    public function testCreateStreamWithArguments(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-connection-stream-args-' . uniqid();
+
+        // Create stream with arguments
+        $connection->createStream($streamName, [
+            'max-length-bytes' => '1000000',
+            'max-age' => '1h'
+        ]);
+
+        // Verify stream exists
+        $this->assertTrue($connection->streamExists($streamName));
+
+        // Cleanup
+        $connection->deleteStream($streamName);
+        $connection->close();
+    }
+
+    public function testGetMetadata(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-metadata-stream-' . uniqid();
+        $connection->createStream($streamName);
+
+        $metadata = $connection->getMetadata([$streamName]);
+        
+        $this->assertNotEmpty($metadata->getStreamMetadata());
+        $this->assertSame($streamName, $metadata->getStreamMetadata()[0]->getStreamName());
+
+        // Cleanup
+        $connection->deleteStream($streamName);
+        $connection->close();
+    }
+
+    public function testGetStreamStats(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-stats-stream-' . uniqid();
+        $connection->createStream($streamName);
+
+        $stats = $connection->getStreamStats($streamName);
+        
+        // Stats should be an array (may be empty for new stream)
+        $this->assertIsArray($stats);
+
+        // Cleanup
+        $connection->deleteStream($streamName);
+        $connection->close();
+    }
+
+    public function testCreateDuplicateStreamThrows(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-duplicate-stream-' . uniqid();
+        
+        // Create stream first time
+        $connection->createStream($streamName);
+
+        // Second create should throw
+        $this->expectException(\Exception::class);
+        $connection->createStream($streamName);
+
+        // Cleanup (won't be reached due to exception)
+        $connection->deleteStream($streamName);
+        $connection->close();
+    }
+}

--- a/tests/E2E/PublishTest.php
+++ b/tests/E2E/PublishTest.php
@@ -2,10 +2,8 @@
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
+use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
-use CrazyGoat\RabbitStream\Client\ProducerConfig;
-use CrazyGoat\RabbitStream\Client\StreamClient;
-use CrazyGoat\RabbitStream\Client\StreamClientConfig;
 use PHPUnit\Framework\TestCase;
 
 class PublishTest extends TestCase
@@ -19,56 +17,63 @@ class PublishTest extends TestCase
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
     }
 
-    private function connect(): StreamClient
+    private function connect(): Connection
     {
-        return StreamClient::connect(new StreamClientConfig(
+        return Connection::create(
             host: self::$host,
             port: self::$port,
-        ));
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
     }
 
     public function testPublishSingleMessage(): void
     {
-        $client = $this->connect();
+        $connection = $this->connect();
 
         $confirmedIds = [];
-        $producer = $client->createProducer('test-stream', new ProducerConfig(
-            onConfirmation: function (ConfirmationStatus $status) use (&$confirmedIds): void {
+        $producer = $connection->createProducer(
+            stream: 'test-stream',
+            onConfirm: function (ConfirmationStatus $status) use (&$confirmedIds): void {
                 if ($status->isConfirmed()) {
                     $confirmedIds[] = $status->getPublishingId();
                 }
             }
-        ));
+        );
 
         $producer->send('hello world');
-        $client->readLoop(maxFrames: 1);
+        $connection->readLoop(maxFrames: 1);
 
         $this->assertSame([0], $confirmedIds);
 
-        $client->close();
+        $producer->close();
+        $connection->close();
     }
 
     public function testPublishMultipleMessages(): void
     {
-        $client = $this->connect();
+        $connection = $this->connect();
 
         $confirmedIds = [];
-        $producer = $client->createProducer('test-stream', new ProducerConfig(
-            onConfirmation: function (ConfirmationStatus $status) use (&$confirmedIds): void {
+        $producer = $connection->createProducer(
+            stream: 'test-stream',
+            onConfirm: function (ConfirmationStatus $status) use (&$confirmedIds): void {
                 if ($status->isConfirmed()) {
                     $confirmedIds[] = $status->getPublishingId();
                 }
             }
-        ));
+        );
 
         $producer->send('message-one');
         $producer->send('message-two');
         $producer->send('message-three');
         
-        $client->readLoop(maxFrames: 3);
+        $connection->readLoop(maxFrames: 3);
 
         $this->assertCount(3, $confirmedIds);
 
-        $client->close();
+        $producer->close();
+        $connection->close();
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the new `Connection` class as the recommended high-level entry point for the RabbitMQ Streams client, replacing the limited `StreamClient`.

### Changes

**New Classes:**
- `Connection` - High-level API with full handshake, stream management, and producer/consumer factory methods
- `Consumer` - Stub class for future consumer implementation

**New Methods in Connection:**
- `create()` - Factory with automatic handshake (PeerProperties → SASL → Tune → Open)
- `createStream()`, `deleteStream()`, `streamExists()` - Stream management
- `getStreamStats()`, `getMetadata()`, `queryOffset()` - Metadata operations
- `close()` - Graceful shutdown with CloseRequestV1
- `createProducer()`, `createConsumer()` - Factory methods
- `readLoop()`, `storeOffset()` - Additional operations

**Updates:**
- Marked `StreamClient` as `@deprecated`
- Added `getMechanisms()` to `SaslHandshakeResponseV1`
- Updated all examples to use `Connection` API
- Updated README.md with new API documentation
- Added comprehensive unit and E2E tests

### Test Plan

- [ ] Run unit tests: `./vendor/bin/phpunit --testsuite unit`
- [ ] Run E2E tests: `./run-e2e.sh`
- [ ] Verify examples work: `php examples/simple_publisher.php`

### BC Impact

Zero breaking changes - `StreamClient` remains functional but is marked deprecated. All existing code continues to work.

Closes #52