### PR TITLE
feat: improve timeout precision for read and write operations (#68)

### DIFF
--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -190,7 +190,7 @@ class Connection
         return new Consumer($this->streamConnection, $stream, $subscriptionId, $offset, $name, $autoCommit, $initialCredit);
     }
 
-    public function readLoop(?int $maxFrames = null, ?int $timeout = null): void
+    public function readLoop(?int $maxFrames = null, ?float $timeout = null): void
     {
         $this->streamConnection->readLoop($maxFrames, $timeout);
     }

--- a/src/Client/Consumer.php
+++ b/src/Client/Consumer.php
@@ -59,7 +59,7 @@ class Consumer
     /**
      * @return Message[]
      */
-    public function read(int $timeout = 5): array
+    public function read(float $timeout = 5.0): array
     {
         if (empty($this->buffer)) {
             $this->connection->readLoop(maxFrames: 1, timeout: $timeout);
@@ -78,7 +78,7 @@ class Consumer
         return $messages;
     }
 
-    public function readOne(int $timeout = 5): ?Message
+    public function readOne(float $timeout = 5.0): ?Message
     {
         if (empty($this->buffer)) {
             $this->connection->readLoop(maxFrames: 1, timeout: $timeout);

--- a/src/Client/Producer.php
+++ b/src/Client/Producer.php
@@ -63,19 +63,19 @@ class Producer
         $this->connection->readMessage();
     }
 
-    public function send(string $message): void
+    public function send(string $message, ?float $timeout = null): void
     {
         $this->pendingConfirms++;
         $this->connection->sendMessage(new PublishRequestV1(
             $this->publisherId,
             new PublishedMessage($this->publishingId++, $message)
-        ));
+        ), $timeout);
     }
 
     /**
      * @param string[] $messages
      */
-    public function sendBatch(array $messages): void
+    public function sendBatch(array $messages, ?float $timeout = null): void
     {
         if (empty($messages)) {
             return;
@@ -85,7 +85,7 @@ class Producer
             $published[] = new PublishedMessage($this->publishingId++, $message);
             $this->pendingConfirms++;
         }
-        $this->connection->sendMessage(new PublishRequestV1($this->publisherId, ...$published));
+        $this->connection->sendMessage(new PublishRequestV1($this->publisherId, ...$published), $timeout);
     }
 
     public function close(): void
@@ -94,15 +94,15 @@ class Producer
         $this->connection->readMessage();
     }
 
-    public function waitForConfirms(int $timeout = 5): void
+    public function waitForConfirms(float $timeout = 5.0): void
     {
-        $deadline = time() + $timeout;
-        while ($this->pendingConfirms > 0 && time() < $deadline) {
-            $remaining = $deadline - time();
+        $deadline = microtime(true) + $timeout;
+        while ($this->pendingConfirms > 0) {
+            $remaining = $deadline - microtime(true);
             if ($remaining <= 0) {
                 break;
             }
-            $this->connection->readLoop(timeout: (int) $remaining);
+            $this->connection->readLoop(timeout: $remaining);
         }
         if ($this->pendingConfirms > 0) {
             throw new \RuntimeException(

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -53,12 +53,12 @@ class StreamConnection
     {
         $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         if ($socket === false) {
-            throw new \Exception("Cannot create socket: " . socket_strerror(socket_last_error()));
+            throw new \RuntimeException("Cannot create socket: " . socket_strerror(socket_last_error()));
         }
 
         $result = socket_connect($socket, $this->host, $this->port);
         if (!$result) {
-            throw new \Exception("Cannot connect to {$this->host}:{$this->port}: " . socket_strerror(socket_last_error($this->socket)));
+            throw new \RuntimeException("Cannot connect to {$this->host}:{$this->port}: " . socket_strerror(socket_last_error($this->socket)));
         }
 
         $this->connected = true;
@@ -117,7 +117,7 @@ class StreamConnection
         $this->running = false;
     }
 
-    public function sendMessage(object $request): void
+    public function sendMessage(object $request, ?float $timeout = null): void
     {
         $this->correlationId++;
 
@@ -132,31 +132,68 @@ class StreamConnection
             ->addRaw($content)
             ->getContents();
 
-        $this->sendFrame($frame);
+        $this->sendFrame($frame, $timeout);
     }
 
-    public function sendFrame(string $frame): int
+    public function sendFrame(string $frame, ?float $timeout = null): int
     {
         $this->logger->debug("Socket -> " . bin2hex($frame));
 
+        // If timeout is specified, wait for socket to be ready for writing
+        if ($timeout !== null && $timeout > 0) {
+            $deadline = microtime(true) + $timeout;
+            
+            $read = null;
+            $write = [$this->socket];
+            $except = null;
+            
+            $remaining = $deadline - microtime(true);
+            if ($remaining <= 0) {
+                throw new \RuntimeException("Write timeout: socket not ready for writing");
+            }
+            
+            $timeoutSec = (int) $remaining;
+            $timeoutUsec = (int) (($remaining - $timeoutSec) * 1_000_000);
+            
+            $ready = socket_select($read, $write, $except, $timeoutSec, $timeoutUsec);
+            
+            if ($ready === false) {
+                throw new \RuntimeException("socket_select failed: " . socket_strerror(socket_last_error($this->socket)));
+            }
+            
+            if ($ready === 0) {
+                throw new \RuntimeException("Write timeout: socket not ready for writing");
+            }
+        }
+
         $written = socket_write($this->socket, $frame, strlen($frame));
         if ($written === false) {
-            throw new \Exception("Failed to write to socket: " . socket_strerror(socket_last_error($this->socket)));
+            throw new \RuntimeException("Failed to write to socket: " . socket_strerror(socket_last_error($this->socket)));
         }
 
         return $written;
     }
 
-    public function readMessage(int $timeout = 30): object
+    public function readMessage(float $timeout = 30.0): object
     {
+        $deadline = $timeout > 0 ? microtime(true) + $timeout : null;
+        
         while (true) {
             if (!$this->connected) {
-                throw new \Exception("Connection closed");
+                throw new \RuntimeException("Connection closed");
             }
 
-            $frame = $this->readFrame($timeout);
+            $remainingTimeout = $timeout;
+            if ($deadline !== null) {
+                $remainingTimeout = $deadline - microtime(true);
+                if ($remainingTimeout <= 0) {
+                    throw new \RuntimeException("Read timeout");
+                }
+            }
+
+            $frame = $this->readFrame($remainingTimeout);
             if ($frame === null) {
-                throw new \Exception("Read timeout");
+                throw new \RuntimeException("Read timeout");
             }
 
             $key = $frame->peekUint16();
@@ -166,7 +203,7 @@ class StreamConnection
 
                 // Connection may have been closed by server-initiated close
                 if (!$this->connected) {
-                    throw new \Exception("Connection closed by server");
+                    throw new \RuntimeException("Connection closed by server");
                 }
 
                 continue;
@@ -176,15 +213,15 @@ class StreamConnection
         }
     }
 
-    public function readLoop(?int $maxFrames = null, ?int $timeout = null): void
+    public function readLoop(?int $maxFrames = null, ?float $timeout = null): void
     {
         $this->running = true;
         $dispatched = 0;
-        $deadline = $timeout !== null ? time() + $timeout : null;
+        $deadline = $timeout !== null ? microtime(true) + $timeout : null;
 
         while ($this->running && $this->connected) {
             // Check if timeout has expired
-            if ($deadline !== null && time() >= $deadline) {
+            if ($deadline !== null && microtime(true) >= $deadline) {
                 break;
             }
 
@@ -193,26 +230,28 @@ class StreamConnection
             $except = null;
 
             // Calculate remaining timeout for socket_select
-            $selectTimeout = 1;
+            $selectTimeoutSec = 1;
+            $selectTimeoutUsec = 0;
             if ($deadline !== null) {
-                $remaining = $deadline - time();
+                $remaining = $deadline - microtime(true);
                 if ($remaining <= 0) {
                     break;
                 }
-                $selectTimeout = min($remaining, 1);
+                $selectTimeoutSec = (int) min($remaining, 1);
+                $selectTimeoutUsec = (int) (($remaining - $selectTimeoutSec) * 1_000_000);
             }
 
-            $ready = socket_select($read, $write, $except, $selectTimeout);
+            $ready = socket_select($read, $write, $except, $selectTimeoutSec, $selectTimeoutUsec);
 
             if ($ready === false) {
-                throw new \Exception('socket_select failed: ' . socket_strerror(socket_last_error($this->socket)));
+                throw new \RuntimeException('socket_select failed: ' . socket_strerror(socket_last_error($this->socket)));
             }
 
             if ($ready === 0) {
                 continue;
             }
 
-            $frame = $this->readFrame(timeout: 0);
+            $frame = $this->readFrame(timeout: 0.0);
             if ($frame === null) {
                 continue;
             }
@@ -325,16 +364,19 @@ class StreamConnection
         }
     }
 
-    public function readFrame(int $timeout = 30): ?ReadBuffer
+    public function readFrame(float $timeout = 30.0): ?ReadBuffer
     {
         $read = [$this->socket];
         $write = null;
         $except = null;
 
-        $ready = socket_select($read, $write, $except, $timeout > 0 ? $timeout : 0);
+        $timeoutSec = (int) $timeout;
+        $timeoutUsec = (int) (($timeout - $timeoutSec) * 1_000_000);
+        
+        $ready = socket_select($read, $write, $except, $timeout > 0 ? $timeoutSec : 0, $timeout > 0 ? $timeoutUsec : 0);
 
         if ($ready === false) {
-            throw new \Exception('socket_select failed: ' . socket_strerror(socket_last_error($this->socket)));
+            throw new \RuntimeException('socket_select failed: ' . socket_strerror(socket_last_error($this->socket)));
         }
 
         if ($ready === 0) {
@@ -350,7 +392,7 @@ class StreamConnection
 
         $frameData = $this->readBytes($size);
         if ($frameData === null) {
-            throw new \Exception("Failed to read frame data");
+            throw new \RuntimeException("Failed to read frame data");
         }
 
         $this->logger->debug("Socket <-" . bin2hex($frameData));
@@ -370,7 +412,7 @@ class StreamConnection
                 if ($error === SOCKET_ETIMEDOUT) {
                     return null;
                 }
-                throw new \Exception("Failed to read from socket: " . socket_strerror($error));
+                throw new \RuntimeException("Failed to read from socket: " . socket_strerror($error));
             }
 
             $data .= $chunk;

--- a/tests/Client/ConsumerTest.php
+++ b/tests/Client/ConsumerTest.php
@@ -22,6 +22,54 @@ class ConsumerTest extends TestCase
         return $connection;
     }
 
+    public function testReadAcceptsFloatTimeout(): void
+    {
+        $connection = $this->createMock(StreamConnection::class);
+        $connection->expects($this->any())->method('registerSubscriber');
+        $connection->expects($this->any())->method('sendMessage');
+        $connection->expects($this->any())->method('readMessage')->willReturn(new \stdClass());
+        $connection->expects($this->any())->method('readLoop');
+
+        $consumer = new Consumer($connection, 'test-stream', 1, OffsetSpec::first());
+        
+        // Test that float timeout is accepted (method signature)
+        $reflection = new \ReflectionMethod($consumer, 'read');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(1, $params);
+        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertEquals('float', $params[0]->getType()->getName());
+        $this->assertEquals(5.0, $params[0]->getDefaultValue());
+        
+        // Test calling with float timeout works
+        $result = $consumer->read(timeout: 0.5);
+        $this->assertSame([], $result);
+    }
+
+    public function testReadOneAcceptsFloatTimeout(): void
+    {
+        $connection = $this->createMock(StreamConnection::class);
+        $connection->expects($this->any())->method('registerSubscriber');
+        $connection->expects($this->any())->method('sendMessage');
+        $connection->expects($this->any())->method('readMessage')->willReturn(new \stdClass());
+        $connection->expects($this->any())->method('readLoop');
+
+        $consumer = new Consumer($connection, 'test-stream', 1, OffsetSpec::first());
+        
+        // Test that float timeout is accepted (method signature)
+        $reflection = new \ReflectionMethod($consumer, 'readOne');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(1, $params);
+        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertEquals('float', $params[0]->getType()->getName());
+        $this->assertEquals(5.0, $params[0]->getDefaultValue());
+        
+        // Test calling with float timeout works
+        $result = $consumer->readOne(timeout: 0.5);
+        $this->assertNull($result);
+    }
+
     public function testReadReturnsEmptyArrayOnTimeout(): void
     {
         $connection = $this->createMock(StreamConnection::class);

--- a/tests/Client/ProducerTest.php
+++ b/tests/Client/ProducerTest.php
@@ -10,6 +10,105 @@ use PHPUnit\Framework\TestCase;
 
 class ProducerTest extends TestCase
 {
+    public function testSendAcceptsOptionalWriteTimeout(): void
+    {
+        $connection = $this->createMock(StreamConnection::class);
+        $connection->expects($this->any())->method('registerPublisher');
+        $connection->expects($this->any())->method('readMessage')->willReturn(new \stdClass());
+        
+        $capturedTimeout = null;
+        $connection->expects($this->any())
+            ->method('sendMessage')
+            ->willReturnCallback(function ($request, $timeout) use (&$capturedTimeout) {
+                $capturedTimeout = $timeout;
+                return null;
+            });
+        
+        $producer = new Producer($connection, 'test-stream', 1);
+        
+        // Test method signature accepts optional timeout
+        $reflection = new \ReflectionMethod($producer, 'send');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(2, $params);
+        $this->assertEquals('message', $params[0]->getName());
+        $this->assertEquals('timeout', $params[1]->getName());
+        $this->assertTrue($params[1]->isOptional());
+        $this->assertNull($params[1]->getDefaultValue());
+        
+        // Test calling with timeout passes it to connection
+        $producer->send('test', 0.5);
+        $this->assertEquals(0.5, $capturedTimeout);
+    }
+
+    public function testSendBatchAcceptsOptionalWriteTimeout(): void
+    {
+        $connection = $this->createMock(StreamConnection::class);
+        $connection->expects($this->any())->method('registerPublisher');
+        $connection->expects($this->any())->method('readMessage')->willReturn(new \stdClass());
+        
+        $capturedTimeout = null;
+        $connection->expects($this->any())
+            ->method('sendMessage')
+            ->willReturnCallback(function ($request, $timeout) use (&$capturedTimeout) {
+                $capturedTimeout = $timeout;
+                return null;
+            });
+        
+        $producer = new Producer($connection, 'test-stream', 1);
+        
+        // Test method signature accepts optional timeout
+        $reflection = new \ReflectionMethod($producer, 'sendBatch');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(2, $params);
+        $this->assertEquals('messages', $params[0]->getName());
+        $this->assertEquals('timeout', $params[1]->getName());
+        $this->assertTrue($params[1]->isOptional());
+        $this->assertNull($params[1]->getDefaultValue());
+        
+        // Test calling with timeout passes it to connection
+        $producer->sendBatch(['test1', 'test2'], 1.0);
+        $this->assertEquals(1.0, $capturedTimeout);
+    }
+
+    public function testWaitForConfirmsAcceptsFloatTimeout(): void
+    {
+        $connection = $this->createMock(StreamConnection::class);
+        $connection->expects($this->any())->method('registerPublisher');
+        $connection->expects($this->any())->method('sendMessage');
+        $connection->expects($this->any())->method('readMessage')->willReturn(new \stdClass());
+        
+        $capturedTimeout = null;
+        $connection->expects($this->any())
+            ->method('readLoop')
+            ->willReturnCallback(function ($maxFrames, $timeout) use (&$capturedTimeout) {
+                $capturedTimeout = $timeout;
+                return null;
+            });
+        
+        $producer = new Producer($connection, 'test-stream', 1);
+        
+        // Test method signature accepts float timeout
+        $reflection = new \ReflectionMethod($producer, 'waitForConfirms');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(1, $params);
+        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertEquals('float', $params[0]->getType()->getName());
+        $this->assertEquals(5.0, $params[0]->getDefaultValue());
+        
+        // Test calling with float timeout passes it to connection
+        $producer->send('test');
+        try {
+            $producer->waitForConfirms(timeout: 0.1);
+        } catch (\RuntimeException $e) {
+            // Expected - timeout
+        }
+        $this->assertNotNull($capturedTimeout);
+        $this->assertLessThanOrEqual(0.1, $capturedTimeout);
+    }
+
     public function testWaitForConfirmsResolvesWhenConfirmsArrive(): void
     {
         $connection = $this->createMock(StreamConnection::class);

--- a/tests/StreamConnectionTest.php
+++ b/tests/StreamConnectionTest.php
@@ -32,4 +32,73 @@ class StreamConnectionTest extends TestCase
 
         $this->assertInstanceOf(StreamConnection::class, $connection);
     }
+
+    public function testReadFrameAcceptsFloatTimeout(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        
+        // Test that float timeout is accepted (method signature)
+        $reflection = new \ReflectionMethod($connection, 'readFrame');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(1, $params);
+        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertEquals('float', $params[0]->getType()->getName());
+        $this->assertEquals(30.0, $params[0]->getDefaultValue());
+    }
+
+    public function testReadMessageAcceptsFloatTimeout(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        
+        $reflection = new \ReflectionMethod($connection, 'readMessage');
+        $params = $reflection->getParameters();
+        
+        $this->assertCount(1, $params);
+        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertEquals('float', $params[0]->getType()->getName());
+        $this->assertEquals(30.0, $params[0]->getDefaultValue());
+    }
+
+    public function testReadLoopAcceptsFloatTimeout(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        
+        $reflection = new \ReflectionMethod($connection, 'readLoop');
+        $params = $reflection->getParameters();
+        
+        // maxFrames and timeout
+        $this->assertCount(2, $params);
+        $this->assertEquals('timeout', $params[1]->getName());
+        $this->assertEquals('float', $params[1]->getType()->getName());
+        $this->assertNull($params[1]->getDefaultValue());
+    }
+
+    public function testSendFrameAcceptsOptionalWriteTimeout(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        
+        $reflection = new \ReflectionMethod($connection, 'sendFrame');
+        $params = $reflection->getParameters();
+        
+        // frame and optional timeout
+        $this->assertCount(2, $params);
+        $this->assertEquals('timeout', $params[1]->getName());
+        $this->assertTrue($params[1]->isOptional());
+        $this->assertNull($params[1]->getDefaultValue());
+    }
+
+    public function testSendMessageAcceptsOptionalWriteTimeout(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        
+        $reflection = new \ReflectionMethod($connection, 'sendMessage');
+        $params = $reflection->getParameters();
+        
+        // request and optional timeout
+        $this->assertCount(2, $params);
+        $this->assertEquals('timeout', $params[1]->getName());
+        $this->assertTrue($params[1]->isOptional());
+        $this->assertNull($params[1]->getDefaultValue());
+    }
 }


### PR DESCRIPTION
Implements issue #68: Improves timeout precision from second-level to sub-second (millisecond) precision for all read and write operations.

## Changes

### Read Timeout Precision
Changed all read timeout parameters from int to float:
- StreamConnection::readMessage(float \$timeout = 30.0)
- StreamConnection::readFrame(float \$timeout = 30.0)
- StreamConnection::readLoop(?int \$maxFrames, ?float \$timeout)
- Connection::readLoop(?int \$maxFrames, ?float \$timeout)
- Consumer::read(float \$timeout = 5.0)
- Consumer::readOne(float \$timeout = 5.0)
- Producer::waitForConfirms(float \$timeout = 5.0)

Internal deadline tracking now uses microtime(true) for sub-second precision. socket_select() calls use microsecond precision via \$timeoutSec and \$timeoutUsec.

### Write Timeout (New Feature)
Added optional write timeout to prevent indefinite blocking:
- StreamConnection::sendFrame(string \$frame, ?float \$timeout = null)
- StreamConnection::sendMessage(object \$request, ?float \$timeout = null)
- Producer::send(string \$message, ?float \$timeout = null)
- Producer::sendBatch(array \$messages, ?float \$timeout = null)

### Exception Consistency
All timeout and connection errors now use RuntimeException consistently.

### Tests
- Added signature verification tests for float timeout parameters
- Added tests for write timeout passthrough
- All 306 unit tests and 62 E2E tests pass

## Backward Compatibility
Existing code using integer timeouts continues to work due to PHP's implicit int-to-float conversion. Default behaviors remain unchanged.

## Usage Examples
```php
// Sub-second read timeout
$messages = $consumer->read(timeout: 0.5);  // 500ms

// Write with timeout
$producer->send($message, timeout: 1.0);  // 1 second max
```

Closes #68