### PR TITLE
feat: bump PHPStan to level 3, all violations fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 2)
+    name: PHPStan (level 3)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
     paths:
         - src
         - tests

--- a/src/Response/CloseResponseV1.php
+++ b/src/Response/CloseResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class CloseResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class CloseResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class ConsumerUpdateQueryV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -51,7 +52,7 @@ class ConsumerUpdateQueryV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self($data['subscriptionId'], $data['active']);
+        $object = new static($data['subscriptionId'], $data['active']);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/CreateResponseV1.php
+++ b/src/Response/CreateResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class CreateResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class CreateResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class CreateSuperStreamResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class CreateSuperStreamResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/CreditResponseV1.php
+++ b/src/Response/CreditResponseV1.php
@@ -12,6 +12,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
@@ -41,7 +42,7 @@ class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->responseCode = $data['responseCode'];
         $object->subscriptionId = $data['subscriptionId'];
         return $object;

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class DeclarePublisherResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class DeclarePublisherResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class DeletePublisherResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class DeletePublisherResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/DeleteStreamResponseV1.php
+++ b/src/Response/DeleteStreamResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class DeleteStreamResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class DeleteStreamResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class DeleteSuperStreamResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class DeleteSuperStreamResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -12,6 +12,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
@@ -49,7 +50,7 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
 
     public static function fromArray(array $data): static
     {
-        return new self($data['subscriptionId'], $data['chunkBytes']);
+        return new static($data['subscriptionId'], $data['chunkBytes']);
     }
 
     public static function getKey(): int

--- a/src/Response/ExchangeCommandVersionsResponseV1.php
+++ b/src/Response/ExchangeCommandVersionsResponseV1.php
@@ -15,6 +15,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\CommandVersion;
 
+/** @phpstan-consistent-constructor */
 class ExchangeCommandVersionsResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -63,7 +64,7 @@ class ExchangeCommandVersionsResponseV1 implements
             ),
             $data['commands']
         );
-        $object = new self($commands);
+        $object = new static($commands);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/MetadataResponseV1.php
+++ b/src/Response/MetadataResponseV1.php
@@ -16,6 +16,7 @@ use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\Broker;
 use CrazyGoat\RabbitStream\VO\StreamMetadata;
 
+/** @phpstan-consistent-constructor */
 class MetadataResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -82,7 +83,7 @@ class MetadataResponseV1 implements
             ),
             $data['streamMetadata']
         );
-        $object = new self($brokers, $streamMetadata);
+        $object = new static($brokers, $streamMetadata);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -12,6 +12,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
@@ -41,7 +42,7 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
 
     public static function fromArray(array $data): static
     {
-        return new self($data['code'], $data['stream']);
+        return new static($data['code'], $data['stream']);
     }
 
     public static function getKey(): int

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -15,6 +15,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
+/** @phpstan-consistent-constructor */
 class OpenResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -39,7 +40,7 @@ class OpenResponseV1 implements
             fn(array $p): \CrazyGoat\RabbitStream\VO\KeyValue => new KeyValue($p['key'], $p['value']),
             $data['connectionProperties']
         );
-        $object = new self(...$properties);
+        $object = new static(...$properties);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class PartitionsResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -57,7 +58,7 @@ class PartitionsResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self($data['streams']);
+        $object = new static($data['streams']);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -15,6 +15,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
+/** @phpstan-consistent-constructor */
 class PeerPropertiesResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -48,7 +49,7 @@ class PeerPropertiesResponseV1 implements
             fn(array $p): \CrazyGoat\RabbitStream\VO\KeyValue => new KeyValue($p['key'], $p['value']),
             $data['properties']
         );
-        $object = new self(...$properties);
+        $object = new static(...$properties);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -12,6 +12,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
@@ -48,7 +49,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
 
     public static function fromArray(array $data): static
     {
-        return new self($data['publisherId'], ...$data['publishingIds']);
+        return new static($data['publisherId'], ...$data['publishingIds']);
     }
 
     public static function getKey(): int

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\PublishingError;
 
+/** @phpstan-consistent-constructor */
 class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
 {
     use CommandTrait;
@@ -56,7 +57,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
             ),
             $data['errors']
         );
-        return new self($data['publisherId'], ...$errors);
+        return new static($data['publisherId'], ...$errors);
     }
 
     public static function getKey(): int

--- a/src/Response/QueryOffsetResponseV1.php
+++ b/src/Response/QueryOffsetResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class QueryOffsetResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -46,7 +47,7 @@ class QueryOffsetResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         $object->offset = $data['offset'];
         return $object;

--- a/src/Response/QueryPublisherSequenceResponseV1.php
+++ b/src/Response/QueryPublisherSequenceResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class QueryPublisherSequenceResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -46,7 +47,7 @@ class QueryPublisherSequenceResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         $object->sequence = $data['sequence'];
         return $object;

--- a/src/Response/ResolveOffsetSpecResponseV1.php
+++ b/src/Response/ResolveOffsetSpecResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class ResolveOffsetSpecResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -47,7 +48,7 @@ class ResolveOffsetSpecResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         $object->offset = $data['offset'];
         return $object;

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class RouteResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -57,7 +58,7 @@ class RouteResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self($data['streams']);
+        $object = new static($data['streams']);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class SaslAuthenticateResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -40,7 +41,7 @@ class SaslAuthenticateResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class SaslHandshakeResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -30,7 +31,7 @@ class SaslHandshakeResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self($data['mechanisms']);
+        $object = new static($data['mechanisms']);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/StreamStatsResponseV1.php
+++ b/src/Response/StreamStatsResponseV1.php
@@ -15,6 +15,7 @@ use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 use CrazyGoat\RabbitStream\VO\Statistic;
 
+/** @phpstan-consistent-constructor */
 class StreamStatsResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -66,7 +67,7 @@ class StreamStatsResponseV1 implements
             fn(array $s): \CrazyGoat\RabbitStream\VO\Statistic => new Statistic($s['key'], $s['value']),
             $data['stats']
         );
-        $object = new self($stats);
+        $object = new static($stats);
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/SubscribeResponseV1.php
+++ b/src/Response/SubscribeResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class SubscribeResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class SubscribeResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/Response/TuneResponseV1.php
+++ b/src/Response/TuneResponseV1.php
@@ -10,6 +10,7 @@ use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 
+/** @phpstan-consistent-constructor */
 class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, FromArrayInterface
 {
     public function __construct(private readonly int $frameMax = 0, private readonly int $heartbeat = 0)
@@ -28,7 +29,7 @@ class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, Fr
 
     public static function fromArray(array $data): static
     {
-        return new self($data['frameMax'], $data['heartbeat']);
+        return new static($data['frameMax'], $data['heartbeat']);
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Response/UnsubscribeResponseV1.php
+++ b/src/Response/UnsubscribeResponseV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class UnsubscribeResponseV1 implements
     KeyVersionInterface,
     CorrelationInterface,
@@ -36,7 +37,7 @@ class UnsubscribeResponseV1 implements
 
     public static function fromArray(array $data): static
     {
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($data['correlationId']);
         return $object;
     }

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -9,6 +9,7 @@ use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
+/** @phpstan-consistent-constructor */
 class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
@@ -53,6 +54,6 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
 
     public static function fromArray(array $data): static
     {
-        return new self($data['reference'], $data['host'], $data['port']);
+        return new static($data['reference'], $data['host'], $data['port']);
     }
 }

--- a/src/VO/CommandVersion.php
+++ b/src/VO/CommandVersion.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
+/** @phpstan-consistent-constructor */
 class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
@@ -63,6 +64,6 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
 
     public static function fromArray(array $data): static
     {
-        return new self($data['key'], $data['minVersion'], $data['maxVersion']);
+        return new static($data['key'], $data['minVersion'], $data['maxVersion']);
     }
 }

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
+/** @phpstan-consistent-constructor */
 class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(private readonly string $key, private readonly ?string $value)
@@ -46,6 +47,6 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, To
 
     public static function fromArray(array $data): static
     {
-        return new self($data['key'], $data['value']);
+        return new static($data['key'], $data['value']);
     }
 }

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -8,6 +8,7 @@ use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
+/** @phpstan-consistent-constructor */
 class PublishingError implements ToArrayInterface, FromArrayInterface
 {
     public function __construct(
@@ -38,6 +39,6 @@ class PublishingError implements ToArrayInterface, FromArrayInterface
 
     public static function fromArray(array $data): static
     {
-        return new self($data['publishingId'], $data['code']);
+        return new static($data['publishingId'], $data['code']);
     }
 }

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 
+/** @phpstan-consistent-constructor */
 class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(private readonly string $key, private readonly int $value)
@@ -46,6 +47,6 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, T
 
     public static function fromArray(array $data): static
     {
-        return new self($data['key'], $data['value']);
+        return new static($data['key'], $data['value']);
     }
 }

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -9,6 +9,7 @@ use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 
+/** @phpstan-consistent-constructor */
 class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
     public function __construct(
@@ -66,6 +67,11 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
 
     public static function fromArray(array $data): static
     {
-        return new self($data['stream'], $data['responseCode'], $data['leaderReference'], $data['replicasReferences']);
+        return new static(
+            $data['stream'],
+            $data['responseCode'],
+            $data['leaderReference'],
+            $data['replicasReferences']
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Bumps PHPStan from level 2 to level 3
- Fixed 34 `return.type` errors: changed `new self()` to `new static()` in `fromArray()` methods
- Fixed line length warning in `StreamMetadata.php`

Closes #77