### PR TITLE
feat: bump PHPStan to level 4, all violations fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 3)
+    name: PHPStan (level 4)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpstan/phpstan": "^2.1"
     },
     "scripts": {
-        "lint": "phpcs --standard=phpcs.xml.dist",
+        "lint": ["phpcs --standard=phpcs.xml.dist", "@rector", "@phpstan"],
         "lint:fix": ["@rector:fix", "phpcbf --standard=phpcs.xml.dist"],
         "phpstan": "phpstan analyse",
         "test": "phpunit",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
     paths:
         - src
         - tests

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -34,6 +34,12 @@ class OpenResponseV1 implements
         $this->connectionProperties = $connectionProperties;
     }
 
+    /** @return KeyValue[] */
+    public function getConnectionProperties(): array
+    {
+        return $this->connectionProperties;
+    }
+
     public static function fromArray(array $data): static
     {
         $properties = array_map(

--- a/tests/Client/AmqpDecoderMessageTest.php
+++ b/tests/Client/AmqpDecoderMessageTest.php
@@ -169,16 +169,7 @@ class AmqpDecoderMessageTest extends TestCase
      */
     private function buildAmqpValueSection(string|int $value): string
     {
-        $valueData = '';
-
-        if (is_string($value)) {
-            $valueData = "\xa1" . chr(strlen($value)) . $value;
-        } elseif (is_int($value)) {
-            $valueData = "\x52" . chr($value);
-        } elseif (is_null($value)) {
-            $valueData = "\x40";
-        }
-
+        $valueData = is_string($value) ? "\xa1" . chr(strlen($value)) . $value : "\x52" . chr($value);
         return $this->buildSection(0x77, $valueData);
     }
 

--- a/tests/Client/ProducerTest.php
+++ b/tests/Client/ProducerTest.php
@@ -143,7 +143,7 @@ class ProducerTest extends TestCase
 
         $producer->waitForConfirms(timeout: 1);
 
-        $this->assertTrue(true);
+        $this->addToAssertionCount(1);
     }
 
     public function testSendBatchCreatesSingleRequestWithMultipleMessages(): void

--- a/tests/E2E/ConnectionTest.php
+++ b/tests/E2E/ConnectionTest.php
@@ -108,10 +108,9 @@ class ConnectionTest extends TestCase
         $streamName = 'test-stats-stream-' . uniqid();
         $connection->createStream($streamName);
 
-        $stats = $connection->getStreamStats($streamName);
+        $connection->getStreamStats($streamName);
 
-        // Stats should be an array (may be empty for new stream)
-        $this->assertIsArray($stats);
+        $this->addToAssertionCount(1);
 
         // Cleanup
         $connection->deleteStream($streamName);

--- a/tests/E2E/ResolveOffsetSpecE2ETest.php
+++ b/tests/E2E/ResolveOffsetSpecE2ETest.php
@@ -133,7 +133,6 @@ class ResolveOffsetSpecE2ETest extends TestCase
 
         $this->assertInstanceOf(ResolveOffsetSpecResponseV1::class, $response);
         $this->assertSame(1, $response->getCorrelationId());
-        $this->assertIsInt($response->getOffset());
         $this->assertGreaterThanOrEqual(0, $response->getOffset());
 
         $connection->close();
@@ -158,7 +157,7 @@ class ResolveOffsetSpecE2ETest extends TestCase
         $response = $connection->readMessage();
 
         $this->assertInstanceOf(ResolveOffsetSpecResponseV1::class, $response);
-        $this->assertIsInt($response->getOffset());
+        $this->assertGreaterThanOrEqual(0, $response->getOffset());
 
         $connection->close();
     }
@@ -182,8 +181,7 @@ class ResolveOffsetSpecE2ETest extends TestCase
         $response = $connection->readMessage();
 
         $this->assertInstanceOf(ResolveOffsetSpecResponseV1::class, $response);
-        // Should return the same offset if it exists, or the closest valid offset
-        $this->assertIsInt($response->getOffset());
+        $this->assertGreaterThanOrEqual(0, $response->getOffset());
 
         $connection->close();
     }

--- a/tests/E2E/StreamStatsTest.php
+++ b/tests/E2E/StreamStatsTest.php
@@ -65,8 +65,7 @@ class StreamStatsTest extends TestCase
         $this->assertInstanceOf(StreamStatsResponseV1::class, $response);
 
         $stats = $response->getStats();
-        $this->assertIsArray($stats);
-        $this->assertGreaterThan(0, count($stats));
+        $this->assertNotEmpty($stats);
 
         $connection->close();
     }


### PR DESCRIPTION
## Summary
- Bumps PHPStan from level 3 to level 4
- Added `getConnectionProperties()` getter to `OpenResponseV1` (property was write-only)
- Removed redundant type assertions (`assertIsInt`, `assertIsArray`, `assertTrue(true)`) in tests
- Simplified unreachable branch in `AmqpDecoderMessageTest`

Closes #78