### PR TITLE
feat: bump PHPStan to level 6, all violations fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 5)
+    name: PHPStan (level 6)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - tests

--- a/src/Buffer/FromArrayInterface.php
+++ b/src/Buffer/FromArrayInterface.php
@@ -6,5 +6,6 @@ namespace CrazyGoat\RabbitStream\Buffer;
 
 interface FromArrayInterface
 {
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static;
 }

--- a/src/Buffer/ReadBuffer.php
+++ b/src/Buffer/ReadBuffer.php
@@ -87,6 +87,7 @@ class ReadBuffer
         return $data;
     }
 
+    /** @return array<int, object> */
     public function getObjectArray(string $class): array
     {
         $arrayLength = $this->getUint32();
@@ -99,6 +100,7 @@ class ReadBuffer
         return $data;
     }
 
+    /** @return array<int, string|null> */
     public function getStringArray(): array
     {
         $arrayLength = $this->getUint32();

--- a/src/Buffer/ToArrayInterface.php
+++ b/src/Buffer/ToArrayInterface.php
@@ -6,5 +6,6 @@ namespace CrazyGoat\RabbitStream\Buffer;
 
 interface ToArrayInterface
 {
+    /** @return array<string, mixed> */
     public function toArray(): array;
 }

--- a/src/Client/AmqpDecoder.php
+++ b/src/Client/AmqpDecoder.php
@@ -76,6 +76,8 @@ class AmqpDecoder
      * Decode a full AMQP 1.0 message into sections.
      * Returns ['header' => [...], 'properties' => [...], 'applicationProperties' => [...],
      *          'messageAnnotations' => [...], 'body' => string|mixed]
+     *
+     * @return array<string, mixed>
      */
     public static function decodeMessage(string $data): array
     {
@@ -158,6 +160,9 @@ class AmqpDecoder
 
     /**
      * Parse Properties list (descriptor 0x73) into named fields.
+     *
+     * @param array<int, mixed> $list
+     * @return array<string, mixed>
      */
     private static function parsePropertiesList(array $list): array
     {
@@ -189,6 +194,7 @@ class AmqpDecoder
 
     // Fixed-width type readers
 
+    /** @return array{0: int, 1: int} */
     private static function readUint8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -197,6 +203,7 @@ class AmqpDecoder
         return [ord($data[$position]), $position + 1];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readInt8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -206,6 +213,7 @@ class AmqpDecoder
         return [$value, $position + 1];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readUint16(string $data, int $position): array
     {
         if ($position + 1 >= strlen($data)) {
@@ -215,6 +223,7 @@ class AmqpDecoder
         return [$value, $position + 2];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readInt16(string $data, int $position): array
     {
         if ($position + 1 >= strlen($data)) {
@@ -224,6 +233,7 @@ class AmqpDecoder
         return [$value, $position + 2];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readUint32(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -237,6 +247,7 @@ class AmqpDecoder
         return [$value, $position + 4];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readInt32(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -246,6 +257,7 @@ class AmqpDecoder
         return [$value, $position + 4];
     }
 
+    /** @return array{0: float, 1: int} */
     private static function readFloat(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -255,6 +267,7 @@ class AmqpDecoder
         return [$value, $position + 4];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readUint64(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -273,6 +286,7 @@ class AmqpDecoder
         return [$value, $position + 8];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readInt64(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -282,6 +296,7 @@ class AmqpDecoder
         return [$value, $position + 8];
     }
 
+    /** @return array{0: float, 1: int} */
     private static function readDouble(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -291,6 +306,7 @@ class AmqpDecoder
         return [$value, $position + 8];
     }
 
+    /** @return array{0: int, 1: int} */
     private static function readTimestamp(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -301,6 +317,7 @@ class AmqpDecoder
         return [$value, $position + 8];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readUuid(string $data, int $position): array
     {
         if ($position + 15 >= strlen($data)) {
@@ -319,6 +336,7 @@ class AmqpDecoder
         return [$value, $position + 16];
     }
 
+    /** @return array{0: bool, 1: int} */
     private static function readBoolean(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -329,6 +347,7 @@ class AmqpDecoder
 
     // Variable-width type readers
 
+    /** @return array{0: string, 1: int} */
     private static function readBinary8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -342,6 +361,7 @@ class AmqpDecoder
         return [substr($data, $position, $length), $position + $length];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readBinary32(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -358,6 +378,7 @@ class AmqpDecoder
         return [substr($data, $position, $length), $position + $length];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readString8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -371,6 +392,7 @@ class AmqpDecoder
         return [substr($data, $position, $length), $position + $length];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readString32(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -387,6 +409,7 @@ class AmqpDecoder
         return [substr($data, $position, $length), $position + $length];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readSymbol8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
@@ -400,6 +423,7 @@ class AmqpDecoder
         return [substr($data, $position, $length), $position + $length];
     }
 
+    /** @return array{0: string, 1: int} */
     private static function readSymbol32(string $data, int $position): array
     {
         if ($position + 3 >= strlen($data)) {
@@ -418,6 +442,7 @@ class AmqpDecoder
 
     // Compound type readers
 
+    /** @return array{0: array<int, mixed>, 1: int} */
     private static function readList8(string $data, int $position): array
     {
         if ($position + 1 >= strlen($data)) {
@@ -440,6 +465,7 @@ class AmqpDecoder
         return [$list, $position];
     }
 
+    /** @return array{0: array<int, mixed>, 1: int} */
     private static function readList32(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -468,6 +494,7 @@ class AmqpDecoder
         return [$list, $position];
     }
 
+    /** @return array{0: array<mixed, mixed>, 1: int} */
     private static function readMap8(string $data, int $position): array
     {
         if ($position + 1 >= strlen($data)) {
@@ -495,6 +522,7 @@ class AmqpDecoder
         return [$map, $position];
     }
 
+    /** @return array{0: array<mixed, mixed>, 1: int} */
     private static function readMap32(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
@@ -530,6 +558,7 @@ class AmqpDecoder
 
     // Described type reader
 
+    /** @return array{0: array{descriptor: mixed, value: mixed}, 1: int} */
     private static function readDescribedType(string $data, int $position): array
     {
         [$descriptor, $position] = self::decodeValue($data, $position);
@@ -539,6 +568,8 @@ class AmqpDecoder
 
     /**
      * Read a described type and return [descriptor, value, newPosition].
+     *
+     * @return array{0: mixed, 1: mixed, 2: int}
      */
     private static function readDescribedTypeWithPosition(string $data, int $position): array
     {

--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -93,6 +93,7 @@ class Connection
         return new self($streamConnection);
     }
 
+    /** @param array<string, string> $arguments */
     public function createStream(string $name, array $arguments = []): void
     {
         $this->streamConnection->sendMessage(new CreateRequestV1($name, $arguments));
@@ -126,6 +127,7 @@ class Connection
         return false;
     }
 
+    /** @return array<string, int> */
     public function getStreamStats(string $name): array
     {
         $this->streamConnection->sendMessage(new StreamStatsRequestV1($name));
@@ -140,6 +142,7 @@ class Connection
         return $result;
     }
 
+    /** @param array<int, string> $streams */
     public function getMetadata(array $streams): MetadataResponseV1
     {
         $this->streamConnection->sendMessage(new MetadataRequestV1($streams));

--- a/src/Client/Message.php
+++ b/src/Client/Message.php
@@ -6,6 +6,12 @@ namespace CrazyGoat\RabbitStream\Client;
 
 class Message
 {
+    /**
+     * @param array<int, mixed>|string|int|float|bool|null $body
+     * @param array<string, mixed> $properties
+     * @param array<string, mixed> $applicationProperties
+     * @param array<string, mixed> $messageAnnotations
+     */
     public function __construct(
         private readonly int $offset,
         private readonly int $timestamp,
@@ -26,21 +32,25 @@ class Message
         return $this->timestamp;
     }
 
+    /** @return array<int, mixed>|string|int|float|bool|null */
     public function getBody(): string|int|float|bool|array|null
     {
         return $this->body;
     }
 
+    /** @return array<string, mixed> */
     public function getProperties(): array
     {
         return $this->properties;
     }
 
+    /** @return array<string, mixed> */
     public function getApplicationProperties(): array
     {
         return $this->applicationProperties;
     }
 
+    /** @return array<string, mixed> */
     public function getMessageAnnotations(): array
     {
         return $this->messageAnnotations;

--- a/src/Request/CloseRequestV1.php
+++ b/src/Request/CloseRequestV1.php
@@ -33,6 +33,7 @@ class CloseRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Corre
             ->addString($this->closingReason);
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/ConsumerUpdateReplyV1.php
+++ b/src/Request/ConsumerUpdateReplyV1.php
@@ -36,6 +36,7 @@ class ConsumerUpdateReplyV1 implements ToStreamBufferInterface, ToArrayInterface
             ->addUInt64($this->offset);
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return [

--- a/src/Request/CreateRequestV1.php
+++ b/src/Request/CreateRequestV1.php
@@ -45,6 +45,7 @@ class CreateRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Corr
         return $buffer;
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/CreateSuperStreamRequestV1.php
+++ b/src/Request/CreateSuperStreamRequestV1.php
@@ -55,6 +55,7 @@ class CreateSuperStreamRequestV1 implements
         return $buffer;
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/CreditRequestV1.php
+++ b/src/Request/CreditRequestV1.php
@@ -30,6 +30,7 @@ class CreditRequestV1 implements ToStreamBufferInterface, ToArrayInterface, KeyV
             ->addUInt16($this->credit);
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return [

--- a/src/Request/DeclarePublisherRequestV1.php
+++ b/src/Request/DeclarePublisherRequestV1.php
@@ -39,6 +39,7 @@ class DeclarePublisherRequestV1 implements
             ->addString($this->stream);
     }
 
+    /** @return array<string, int|string|null> */
     public function toArray(): array
     {
         return [

--- a/src/Request/DeletePublisherRequestV1.php
+++ b/src/Request/DeletePublisherRequestV1.php
@@ -34,6 +34,7 @@ class DeletePublisherRequestV1 implements
             ->addUInt8($this->publisherId);
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return ['publisherId' => $this->publisherId];

--- a/src/Request/DeleteStreamRequestV1.php
+++ b/src/Request/DeleteStreamRequestV1.php
@@ -34,6 +34,7 @@ class DeleteStreamRequestV1 implements
             ->addString($this->stream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return ['stream' => $this->stream];

--- a/src/Request/DeleteSuperStreamRequestV1.php
+++ b/src/Request/DeleteSuperStreamRequestV1.php
@@ -34,6 +34,7 @@ class DeleteSuperStreamRequestV1 implements
             ->addString($this->name);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return ['name' => $this->name];

--- a/src/Request/ExchangeCommandVersionsRequestV1.php
+++ b/src/Request/ExchangeCommandVersionsRequestV1.php
@@ -38,6 +38,7 @@ class ExchangeCommandVersionsRequestV1 implements
             ->addArray(...$this->commands);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return ['commands' => array_map(fn(CommandVersion $cv): array => $cv->toArray(), $this->commands)];

--- a/src/Request/HeartbeatRequestV1.php
+++ b/src/Request/HeartbeatRequestV1.php
@@ -33,6 +33,7 @@ class HeartbeatRequestV1 implements
         return self::getKeyVersion();
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [];

--- a/src/Request/MetadataRequestV1.php
+++ b/src/Request/MetadataRequestV1.php
@@ -39,6 +39,7 @@ class MetadataRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Co
         return $buffer;
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return ['streams' => $this->streams];

--- a/src/Request/OpenRequest.php
+++ b/src/Request/OpenRequest.php
@@ -30,6 +30,7 @@ class OpenRequest implements KeyVersionInterface, ToStreamBufferInterface, ToArr
             ->addString($this->vhost);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return ['vhost' => $this->vhost];

--- a/src/Request/PartitionsRequestV1.php
+++ b/src/Request/PartitionsRequestV1.php
@@ -34,6 +34,7 @@ class PartitionsRequestV1 implements
             ->addString($this->superStream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return ['superStream' => $this->superStream];

--- a/src/Request/PeerPropertiesToStreamBufferV1.php
+++ b/src/Request/PeerPropertiesToStreamBufferV1.php
@@ -25,6 +25,7 @@ class PeerPropertiesToStreamBufferV1 implements
     use V1Trait;
     use CommandTrait;
 
+    /** @var array<int, KeyValue> */
     private array $keyValues;
 
     public function __construct(KeyValue ...$keyValues)
@@ -38,6 +39,7 @@ class PeerPropertiesToStreamBufferV1 implements
             ->addArray(...$this->keyValues);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return ['properties' => array_map(fn(KeyValue $kv): array => $kv->toArray(), $this->keyValues)];

--- a/src/Request/PublishRequestV1.php
+++ b/src/Request/PublishRequestV1.php
@@ -18,6 +18,7 @@ class PublishRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Key
     use V1Trait;
     use CommandTrait;
 
+    /** @var array<int, PublishedMessage> */
     private array $messages;
 
     public function __construct(private int $publisherId, PublishedMessage ...$messages)
@@ -32,6 +33,7 @@ class PublishRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Key
             ->addArray(...$this->messages);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/PublishRequestV2.php
+++ b/src/Request/PublishRequestV2.php
@@ -18,6 +18,7 @@ class PublishRequestV2 implements ToStreamBufferInterface, ToArrayInterface, Key
     use V1Trait;
     use CommandTrait;
 
+    /** @var array<int, PublishedMessageV2> */
     private array $messages;
 
     public function __construct(private int $publisherId, PublishedMessageV2 ...$messages)
@@ -32,6 +33,7 @@ class PublishRequestV2 implements ToStreamBufferInterface, ToArrayInterface, Key
             ->addArray(...$this->messages);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/QueryOffsetRequestV1.php
+++ b/src/Request/QueryOffsetRequestV1.php
@@ -37,6 +37,7 @@ class QueryOffsetRequestV1 implements
             ->addString($this->stream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/QueryPublisherSequenceRequestV1.php
+++ b/src/Request/QueryPublisherSequenceRequestV1.php
@@ -37,6 +37,7 @@ class QueryPublisherSequenceRequestV1 implements
             ->addString($this->stream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/ResolveOffsetSpecRequestV1.php
+++ b/src/Request/ResolveOffsetSpecRequestV1.php
@@ -39,6 +39,7 @@ class ResolveOffsetSpecRequestV1 implements
             ->addUInt32(0); // Properties array length (0 = empty array)
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/RouteRequestV1.php
+++ b/src/Request/RouteRequestV1.php
@@ -33,6 +33,7 @@ class RouteRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Corre
             ->addString($this->superStream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/SaslAuthenticateRequestV1.php
+++ b/src/Request/SaslAuthenticateRequestV1.php
@@ -34,6 +34,7 @@ class SaslAuthenticateRequestV1 implements
             ->addBytes("\0" . $this->username . "\0" . $this->password);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/SaslHandshakeRequestV1.php
+++ b/src/Request/SaslHandshakeRequestV1.php
@@ -29,6 +29,7 @@ class SaslHandshakeRequestV1 implements
         return self::getKeyVersion($this->getCorrelationId());
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [];

--- a/src/Request/StoreOffsetRequestV1.php
+++ b/src/Request/StoreOffsetRequestV1.php
@@ -32,6 +32,7 @@ class StoreOffsetRequestV1 implements ToStreamBufferInterface, ToArrayInterface,
             ->addUInt64($this->offset);
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return [

--- a/src/Request/StreamStatsRequestV1.php
+++ b/src/Request/StreamStatsRequestV1.php
@@ -34,6 +34,7 @@ class StreamStatsRequestV1 implements
             ->addString($this->stream);
     }
 
+    /** @return array<string, string> */
     public function toArray(): array
     {
         return ['stream' => $this->stream];

--- a/src/Request/SubscribeRequestV1.php
+++ b/src/Request/SubscribeRequestV1.php
@@ -38,6 +38,7 @@ class SubscribeRequestV1 implements ToStreamBufferInterface, ToArrayInterface, C
             ->addUInt16($this->credit);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/Request/TuneRequestV1.php
+++ b/src/Request/TuneRequestV1.php
@@ -52,6 +52,7 @@ class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterfac
         return $this->heartbeat;
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return [

--- a/src/Request/UnsubscribeRequestV1.php
+++ b/src/Request/UnsubscribeRequestV1.php
@@ -34,6 +34,7 @@ class UnsubscribeRequestV1 implements
             ->addUInt8($this->subscriptionId);
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return ['subscriptionId' => $this->subscriptionId];

--- a/src/Response/CloseResponseV1.php
+++ b/src/Response/CloseResponseV1.php
@@ -35,6 +35,7 @@ class CloseResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -50,6 +50,7 @@ class ConsumerUpdateQueryV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static($data['subscriptionId'], $data['active']);

--- a/src/Response/CreateResponseV1.php
+++ b/src/Response/CreateResponseV1.php
@@ -35,6 +35,7 @@ class CreateResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -35,6 +35,7 @@ class CreateSuperStreamResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/CreditResponseV1.php
+++ b/src/Response/CreditResponseV1.php
@@ -40,6 +40,7 @@ class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
         return $this->responseCode;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -35,6 +35,7 @@ class DeclarePublisherResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -35,6 +35,7 @@ class DeletePublisherResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/DeleteStreamResponseV1.php
+++ b/src/Response/DeleteStreamResponseV1.php
@@ -35,6 +35,7 @@ class DeleteStreamResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -35,6 +35,7 @@ class DeleteSuperStreamResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -48,6 +48,7 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
         return new self($subscriptionId, $chunkBytes);
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['subscriptionId'], $data['chunkBytes']);

--- a/src/Response/ExchangeCommandVersionsResponseV1.php
+++ b/src/Response/ExchangeCommandVersionsResponseV1.php
@@ -54,6 +54,7 @@ class ExchangeCommandVersionsResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $commands = array_map(

--- a/src/Response/MetadataResponseV1.php
+++ b/src/Response/MetadataResponseV1.php
@@ -68,6 +68,7 @@ class MetadataResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $brokers = array_map(

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -40,6 +40,7 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
         return new self($code, $stream);
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['code'], $data['stream']);

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -40,6 +40,7 @@ class OpenResponseV1 implements
         return $this->connectionProperties;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $properties = array_map(

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -56,6 +56,7 @@ class PartitionsResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static($data['streams']);

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -26,6 +26,7 @@ class PeerPropertiesResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
+    /** @var array<int, KeyValue> */
     private array $peerProperty;
 
     public function __construct(KeyValue ...$peerProperty)
@@ -33,6 +34,7 @@ class PeerPropertiesResponseV1 implements
         $this->peerProperty = $peerProperty;
     }
 
+    /** @return array<int, KeyValue> */
     public function getPeerProperty(): array
     {
         return $this->peerProperty;
@@ -43,6 +45,7 @@ class PeerPropertiesResponseV1 implements
         return KeyEnum::PEER_PROPERTIES_RESPONSE->value;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $properties = array_map(

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -18,6 +18,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
     use CommandTrait;
     use V1Trait;
 
+    /** @var array<int, int> */
     private array $publishingIds;
 
     public function __construct(private int $publisherId, int ...$publishingIds)
@@ -30,6 +31,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
         return $this->publisherId;
     }
 
+    /** @return array<int, int> */
     public function getPublishingIds(): array
     {
         return $this->publishingIds;
@@ -47,6 +49,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
         return new self($publisherId, ...$publishingIds);
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['publisherId'], ...$data['publishingIds']);

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -19,6 +19,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
     use CommandTrait;
     use V1Trait;
 
+    /** @var array<int, PublishingError> */
     private array $errors;
 
     public function __construct(private int $publisherId, PublishingError ...$errors)
@@ -31,6 +32,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
         return $this->publisherId;
     }
 
+    /** @return array<int, PublishingError> */
     public function getErrors(): array
     {
         return $this->errors;
@@ -48,6 +50,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
         return new self($publisherId, ...$errors);
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $errors = array_map(

--- a/src/Response/QueryOffsetResponseV1.php
+++ b/src/Response/QueryOffsetResponseV1.php
@@ -45,6 +45,7 @@ class QueryOffsetResponseV1 implements
         return KeyEnum::QUERY_OFFSET_RESPONSE->value;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/QueryPublisherSequenceResponseV1.php
+++ b/src/Response/QueryPublisherSequenceResponseV1.php
@@ -45,6 +45,7 @@ class QueryPublisherSequenceResponseV1 implements
         return KeyEnum::QUERY_PUBLISHER_SEQUENCE_RESPONSE->value;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/ResolveOffsetSpecResponseV1.php
+++ b/src/Response/ResolveOffsetSpecResponseV1.php
@@ -46,6 +46,7 @@ class ResolveOffsetSpecResponseV1 implements
         return KeyEnum::RESOLVE_OFFSET_SPEC_RESPONSE->value;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -56,6 +56,7 @@ class RouteResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static($data['streams']);

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -39,6 +39,7 @@ class SaslAuthenticateResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -25,10 +25,12 @@ class SaslHandshakeResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
+    /** @param array<int, string|null> $mechanisms */
     public function __construct(private array $mechanisms)
     {
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static($data['mechanisms']);
@@ -36,6 +38,7 @@ class SaslHandshakeResponseV1 implements
         return $object;
     }
 
+    /** @return array<int, string|null> */
     public function getMechanisms(): array
     {
         return $this->mechanisms;

--- a/src/Response/StreamStatsResponseV1.php
+++ b/src/Response/StreamStatsResponseV1.php
@@ -61,6 +61,7 @@ class StreamStatsResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $stats = array_map(

--- a/src/Response/SubscribeResponseV1.php
+++ b/src/Response/SubscribeResponseV1.php
@@ -35,6 +35,7 @@ class SubscribeResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/Response/TuneResponseV1.php
+++ b/src/Response/TuneResponseV1.php
@@ -27,6 +27,7 @@ class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, Fr
         return KeyEnum::TUNE_RESPONSE->value;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['frameMax'], $data['heartbeat']);

--- a/src/Response/UnsubscribeResponseV1.php
+++ b/src/Response/UnsubscribeResponseV1.php
@@ -35,6 +35,7 @@ class UnsubscribeResponseV1 implements
         return $object;
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         $object = new static();

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -27,7 +27,9 @@ class StreamConnection
     private int $correlationId = 0;
     private bool $running = false;
 
+    /** @var array<int, array{onConfirm: callable, onError: callable}> */
     private array $publisherCallbacks = [];
+    /** @var array<int, callable> */
     private array $subscriberCallbacks = [];
     private ?\Closure $metadataUpdateCallback = null;
     private ?\Closure $heartbeatCallback = null;

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -43,6 +43,7 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
         );
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return [
@@ -52,6 +53,7 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
         ];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['reference'], $data['host'], $data['port']);

--- a/src/VO/CommandVersion.php
+++ b/src/VO/CommandVersion.php
@@ -53,6 +53,7 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
             ->addUInt16($this->maxVersion);
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return [
@@ -62,6 +63,7 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
         ];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['key'], $data['minVersion'], $data['maxVersion']);

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -40,11 +40,13 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, To
         return new self($buffer->getString(), $buffer->getString());
     }
 
+    /** @return array<string, string|null> */
     public function toArray(): array
     {
         return ['key' => $this->key, 'value' => $this->value];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['key'], $data['value']);

--- a/src/VO/OffsetSpec.php
+++ b/src/VO/OffsetSpec.php
@@ -91,6 +91,7 @@ class OffsetSpec implements ToStreamBufferInterface, ToArrayInterface
         return $this->value;
     }
 
+    /** @return array<string, int|null> */
     public function toArray(): array
     {
         return ['type' => $this->type, 'value' => $this->value];

--- a/src/VO/PublishedMessage.php
+++ b/src/VO/PublishedMessage.php
@@ -28,6 +28,7 @@ class PublishedMessage implements ToStreamBufferInterface, ToArrayInterface
         return $this->publishingId;
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return ['publishingId' => $this->publishingId, 'data' => $this->message];

--- a/src/VO/PublishedMessageV2.php
+++ b/src/VO/PublishedMessageV2.php
@@ -30,6 +30,7 @@ class PublishedMessageV2 implements ToStreamBufferInterface, ToArrayInterface
         return $this->publishingId;
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return [

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -32,11 +32,13 @@ class PublishingError implements ToArrayInterface, FromArrayInterface
         return new self($buffer->getUint64(), $buffer->getUint16());
     }
 
+    /** @return array<string, int> */
     public function toArray(): array
     {
         return ['publishingId' => $this->publishingId, 'code' => $this->code];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['publishingId'], $data['code']);

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -40,11 +40,13 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, T
         return new self($buffer->getString(), $buffer->getInt64());
     }
 
+    /** @return array<string, int|string> */
     public function toArray(): array
     {
         return ['key' => $this->key, 'value' => $this->value];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static($data['key'], $data['value']);

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -12,6 +12,7 @@ use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 /** @phpstan-consistent-constructor */
 class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
 {
+    /** @param array<int, int> $replicasReferences */
     public function __construct(
         private readonly string $streamName,
         private readonly int $responseCode,
@@ -35,6 +36,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
         return $this->leaderReference;
     }
 
+    /** @return array<int, int> */
     public function getReplicasReferences(): array
     {
         return $this->replicasReferences;
@@ -55,6 +57,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
         return new self($streamName, $responseCode, $leaderReference, $replicasReferences);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [
@@ -65,6 +68,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
         ];
     }
 
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
         return new static(

--- a/tests/Client/AmqpDecoderMessageTest.php
+++ b/tests/Client/AmqpDecoderMessageTest.php
@@ -31,6 +31,8 @@ class AmqpDecoderMessageTest extends TestCase
 
     /**
      * Helper to build a Properties section (0x73) from a list.
+     *
+     * @param array<string, string|int> $properties
      */
     private function buildPropertiesSection(array $properties): string
     {
@@ -96,6 +98,8 @@ class AmqpDecoderMessageTest extends TestCase
 
     /**
      * Helper to build an ApplicationProperties section (0x74) from a map.
+     *
+     * @param array<string, string|int|bool|null> $properties
      */
     private function buildApplicationPropertiesSection(array $properties): string
     {
@@ -134,6 +138,8 @@ class AmqpDecoderMessageTest extends TestCase
 
     /**
      * Helper to build a MessageAnnotations section (0x72) from a map.
+     *
+     * @param array<string, string|int> $annotations
      */
     private function buildMessageAnnotationsSection(array $annotations): string
     {

--- a/tests/Client/AmqpMessageDecoderTest.php
+++ b/tests/Client/AmqpMessageDecoderTest.php
@@ -23,6 +23,8 @@ class AmqpMessageDecoderTest extends TestCase
 
     /**
      * Helper to build a Properties section.
+     *
+     * @param array<string, string|int> $properties
      */
     private function buildPropertiesSection(array $properties): string
     {
@@ -83,6 +85,8 @@ class AmqpMessageDecoderTest extends TestCase
 
     /**
      * Helper to build an ApplicationProperties section.
+     *
+     * @param array<string, string|int|bool> $properties
      */
     private function buildApplicationPropertiesSection(array $properties): string
     {

--- a/tests/Client/OsirisChunkParserTest.php
+++ b/tests/Client/OsirisChunkParserTest.php
@@ -164,6 +164,9 @@ class OsirisChunkParserTest extends TestCase
         $this->assertSame('Last', $entries[3]->getData());
     }
 
+    /**
+     * @param array<int, array<string, mixed>> $entries
+     */
     private function createChunk(
         int $numEntries,
         int $numRecords,

--- a/tests/E2E/AmqpMessageDecoderE2ETest.php
+++ b/tests/E2E/AmqpMessageDecoderE2ETest.php
@@ -82,6 +82,8 @@ class AmqpMessageDecoderE2ETest extends TestCase
 
     /**
      * Build an AMQP 1.0 message with Properties and Data sections
+     *
+     * @param array<string, string|int> $properties
      */
     private function buildAmqpMessageWithProperties(string $body, array $properties): string
     {
@@ -145,6 +147,8 @@ class AmqpMessageDecoderE2ETest extends TestCase
 
     /**
      * Build an AMQP 1.0 message with ApplicationProperties and Data sections
+     *
+     * @param array<string, string|int|bool> $appProperties
      */
     private function buildAmqpMessageWithAppProperties(string $body, array $appProperties): string
     {


### PR DESCRIPTION
## Summary
- Bumps PHPStan from level 5 to level 6
- Added PHPDoc array type annotations to 76 files (137 errors fixed)
- No runtime code changes — only `@param`/`@return` annotations

Closes #80