### PR TITLE
feat: bump PHPStan to level 7, all violations fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 6)
+    name: PHPStan (level 7)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
     paths:
         - src
         - tests

--- a/src/Buffer/FromStreamBufferInterface.php
+++ b/src/Buffer/FromStreamBufferInterface.php
@@ -6,5 +6,5 @@ namespace CrazyGoat\RabbitStream\Buffer;
 
 interface FromStreamBufferInterface
 {
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object;
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static;
 }

--- a/src/Buffer/ReadBuffer.php
+++ b/src/Buffer/ReadBuffer.php
@@ -14,16 +14,22 @@ class ReadBuffer
 
     public function getUint8(): int
     {
-        $data = unpack('C', substr($this->buffer, $this->position, 1))[1];
+        $data = unpack('C', substr($this->buffer, $this->position, 1));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack uint8 at position ' . $this->position);
+        }
         $this->position += 1;
-        return $data;
+        return $data[1];
     }
 
     public function getUint16(): int
     {
-        $data = unpack('n', substr($this->buffer, $this->position, 2))[1];
+        $data = unpack('n', substr($this->buffer, $this->position, 2));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack uint16 at position ' . $this->position);
+        }
         $this->position += 2;
-        return $data;
+        return $data[1];
     }
 
     public function rewind(): void
@@ -33,26 +39,35 @@ class ReadBuffer
 
     public function getUint32(): int
     {
-        $data = unpack('N', substr($this->buffer, $this->position, 4))[1];
+        $data = unpack('N', substr($this->buffer, $this->position, 4));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack uint32 at position ' . $this->position);
+        }
         $this->position += 4;
-        return $data;
+        return $data[1];
     }
 
     public function getUint64(): int
     {
-        $data = unpack('J', substr($this->buffer, $this->position, 8))[1];
+        $data = unpack('J', substr($this->buffer, $this->position, 8));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack uint64 at position ' . $this->position);
+        }
         $this->position += 8;
-        return $data;
+        return $data[1];
     }
 
     public function getInt64(): int
     {
-        $data = unpack('J', substr($this->buffer, $this->position, 8))[1];
-        $this->position += 8;
-        if ($data >= 0x8000000000000000) {
-            $data -= 0x10000000000000000;
+        $data = unpack('J', substr($this->buffer, $this->position, 8));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack int64 at position ' . $this->position);
         }
-        return $data;
+        $this->position += 8;
+        if ($data[1] >= 0x8000000000000000) {
+            $data[1] -= 0x10000000000000000;
+        }
+        return $data[1];
     }
 
     public function getString(): ?string
@@ -69,32 +84,46 @@ class ReadBuffer
 
     public function getInt16(): int
     {
-        $data = unpack('n', substr($this->buffer, $this->position, 2))[1];
-        $this->position += 2;
-        if ($data >= 0x8000) {
-            $data -= 0x10000;
+        $data = unpack('n', substr($this->buffer, $this->position, 2));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack int16 at position ' . $this->position);
         }
-        return $data;
+        $this->position += 2;
+        if ($data[1] >= 0x8000) {
+            $data[1] -= 0x10000;
+        }
+        return $data[1];
     }
 
     public function getInt32(): int
     {
-        $data = unpack('N', substr($this->buffer, $this->position, 4))[1];
-        $this->position += 4;
-        if ($data >= 0x80000000) {
-            $data -= 0x100000000;
+        $data = unpack('N', substr($this->buffer, $this->position, 4));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack int32 at position ' . $this->position);
         }
-        return $data;
+        $this->position += 4;
+        if ($data[1] >= 0x80000000) {
+            $data[1] -= 0x100000000;
+        }
+        return $data[1];
     }
 
-    /** @return array<int, object> */
+    /**
+     * @template T of FromStreamBufferInterface
+     * @param class-string<T> $class
+     * @return array<int, T>
+     */
     public function getObjectArray(string $class): array
     {
         $arrayLength = $this->getUint32();
 
         $data = [];
         for ($i = 0; $i < $arrayLength; $i++) {
-            $data[] = $class::fromStreamBuffer($this);
+            $item = $class::fromStreamBuffer($this);
+            if ($item === null) {
+                throw new \RuntimeException('Failed to deserialize object of class ' . $class);
+            }
+            $data[] = $item;
         }
 
         return $data;
@@ -151,6 +180,10 @@ class ReadBuffer
 
     public function peekUint16(): int
     {
-        return unpack('n', substr($this->buffer, $this->position, 2))[1];
+        $data = unpack('n', substr($this->buffer, $this->position, 2));
+        if ($data === false) {
+            throw new \RuntimeException('Failed to unpack uint16 at position ' . $this->position);
+        }
+        return $data[1];
     }
 }

--- a/src/Buffer/WriteBuffer.php
+++ b/src/Buffer/WriteBuffer.php
@@ -114,6 +114,9 @@ class WriteBuffer
             $this->buffer .= pack('n', 0xFFFF); // -1 as unsigned int16
         } else {
             $utf8Value = mb_convert_encoding($value, 'UTF-8', 'auto');
+            if ($utf8Value === false) {
+                throw new \RuntimeException('Failed to convert string to UTF-8');
+            }
             $length = strlen($utf8Value);
             $this->validateInt($length, 0, self::INT16_MAX, 'string length');
             $this->buffer .= pack('n', $length);

--- a/src/Client/AmqpDecoder.php
+++ b/src/Client/AmqpDecoder.php
@@ -203,13 +203,25 @@ class AmqpDecoder
         return [ord($data[$position]), $position + 1];
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
+    private static function safeUnpack(string $format, string $data, string $context): array
+    {
+        $result = unpack($format, $data);
+        if ($result === false) {
+            throw new \RuntimeException('Failed to unpack ' . $context);
+        }
+        return $result;
+    }
+
     /** @return array{0: int, 1: int} */
     private static function readInt8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int8');
         }
-        $value = unpack('c', $data[$position])[1];
+        $value = self::safeUnpack('c', $data[$position], 'int8')[1];
         return [$value, $position + 1];
     }
 
@@ -219,7 +231,7 @@ class AmqpDecoder
         if ($position + 1 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint16');
         }
-        $value = unpack('n', substr($data, $position, 2))[1];
+        $value = self::safeUnpack('n', substr($data, $position, 2), 'uint16')[1];
         return [$value, $position + 2];
     }
 
@@ -229,7 +241,7 @@ class AmqpDecoder
         if ($position + 1 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int16');
         }
-        $value = unpack('s', strrev(substr($data, $position, 2)))[1];
+        $value = self::safeUnpack('s', strrev(substr($data, $position, 2)), 'int16')[1];
         return [$value, $position + 2];
     }
 
@@ -239,7 +251,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint32');
         }
-        $value = unpack('N', substr($data, $position, 4))[1];
+        $value = self::safeUnpack('N', substr($data, $position, 4), 'uint32')[1];
         // Handle unsigned 32-bit values > PHP_INT_MAX
         if ($value < 0) {
             $value += 4294967296;
@@ -253,7 +265,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int32');
         }
-        $value = unpack('l', strrev(substr($data, $position, 4)))[1];
+        $value = self::safeUnpack('l', strrev(substr($data, $position, 4)), 'int32')[1];
         return [$value, $position + 4];
     }
 
@@ -263,7 +275,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading float');
         }
-        $value = unpack('f', strrev(substr($data, $position, 4)))[1];
+        $value = self::safeUnpack('f', strrev(substr($data, $position, 4)), 'float')[1];
         return [$value, $position + 4];
     }
 
@@ -273,8 +285,8 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint64');
         }
-        $high = unpack('N', substr($data, $position, 4))[1];
-        $low = unpack('N', substr($data, $position + 4, 4))[1];
+        $high = self::safeUnpack('N', substr($data, $position, 4), 'uint64 high')[1];
+        $low = self::safeUnpack('N', substr($data, $position + 4, 4), 'uint64 low')[1];
         // Handle as string for large values
         if ($high < 0) {
             $high += 4294967296;
@@ -292,7 +304,7 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int64');
         }
-        $value = unpack('q', strrev(substr($data, $position, 8)))[1];
+        $value = self::safeUnpack('q', strrev(substr($data, $position, 8)), 'int64')[1];
         return [$value, $position + 8];
     }
 
@@ -302,7 +314,7 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading double');
         }
-        $value = unpack('d', strrev(substr($data, $position, 8)))[1];
+        $value = self::safeUnpack('d', strrev(substr($data, $position, 8)), 'double')[1];
         return [$value, $position + 8];
     }
 
@@ -313,7 +325,7 @@ class AmqpDecoder
             throw new \RuntimeException('Unexpected end of data reading timestamp');
         }
         // Timestamp is milliseconds since Unix epoch (int64)
-        $value = unpack('q', strrev(substr($data, $position, 8)))[1];
+        $value = self::safeUnpack('q', strrev(substr($data, $position, 8)), 'timestamp')[1];
         return [$value, $position + 8];
     }
 
@@ -325,13 +337,19 @@ class AmqpDecoder
         }
         $bytes = substr($data, $position, 16);
         // Format as UUID string: 8-4-4-4-12 hex digits
+        $p1 = self::safeUnpack('N', substr($bytes, 0, 4), 'uuid part1')[1];
+        $p2 = self::safeUnpack('n', substr($bytes, 4, 2), 'uuid part2')[1];
+        $p3 = self::safeUnpack('n', substr($bytes, 6, 2), 'uuid part3')[1];
+        $p4 = self::safeUnpack('n', substr($bytes, 8, 2), 'uuid part4')[1];
+        $p5a = self::safeUnpack('N', substr($bytes, 10, 4), 'uuid part5a')[1];
+        $p5b = self::safeUnpack('n', substr($bytes, 14, 2), 'uuid part5b')[1];
         $value = sprintf(
             '%08x-%04x-%04x-%04x-%012x',
-            unpack('N', substr($bytes, 0, 4))[1],
-            unpack('n', substr($bytes, 4, 2))[1],
-            unpack('n', substr($bytes, 6, 2))[1],
-            unpack('n', substr($bytes, 8, 2))[1],
-            unpack('N', substr($bytes, 10, 4))[1] * 65536 + unpack('n', substr($bytes, 14, 2))[1]
+            $p1,
+            $p2,
+            $p3,
+            $p4,
+            $p5a * 65536 + $p5b
         );
         return [$value, $position + 16];
     }
@@ -367,7 +385,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading binary32 length');
         }
-        $length = unpack('N', substr($data, $position, 4))[1];
+        $length = self::safeUnpack('N', substr($data, $position, 4), 'binary32 length')[1];
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -398,7 +416,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading string32 length');
         }
-        $length = unpack('N', substr($data, $position, 4))[1];
+        $length = self::safeUnpack('N', substr($data, $position, 4), 'string32 length')[1];
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -429,7 +447,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading symbol32 length');
         }
-        $length = unpack('N', substr($data, $position, 4))[1];
+        $length = self::safeUnpack('N', substr($data, $position, 4), 'symbol32 length')[1];
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -471,11 +489,11 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading list32 header');
         }
-        $size = unpack('N', substr($data, $position, 4))[1];
+        $size = self::safeUnpack('N', substr($data, $position, 4), 'list32 size')[1];
         if ($size < 0) {
             $size += 4294967296;
         }
-        $count = unpack('N', substr($data, $position + 4, 4))[1];
+        $count = self::safeUnpack('N', substr($data, $position + 4, 4), 'list32 count')[1];
         if ($count < 0) {
             $count += 4294967296;
         }
@@ -528,11 +546,11 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading map32 header');
         }
-        $size = unpack('N', substr($data, $position, 4))[1];
+        $size = self::safeUnpack('N', substr($data, $position, 4), 'map32 size')[1];
         if ($size < 0) {
             $size += 4294967296;
         }
-        $count = unpack('N', substr($data, $position + 4, 4))[1];
+        $count = self::safeUnpack('N', substr($data, $position + 4, 4), 'map32 count')[1];
         if ($count < 0) {
             $count += 4294967296;
         }

--- a/src/Request/HeartbeatRequestV1.php
+++ b/src/Request/HeartbeatRequestV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class HeartbeatRequestV1 implements
     FromStreamBufferInterface,
     ToStreamBufferInterface,
@@ -39,9 +40,9 @@ class HeartbeatRequestV1 implements
         return [];
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
-        return new self();
+        return new static();
     }
 }

--- a/src/Request/PeerPropertiesToStreamBufferV1.php
+++ b/src/Request/PeerPropertiesToStreamBufferV1.php
@@ -30,7 +30,7 @@ class PeerPropertiesToStreamBufferV1 implements
 
     public function __construct(KeyValue ...$keyValues)
     {
-        $this->keyValues = $keyValues;
+        $this->keyValues = array_values($keyValues);
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Request/PublishRequestV1.php
+++ b/src/Request/PublishRequestV1.php
@@ -23,7 +23,7 @@ class PublishRequestV1 implements ToStreamBufferInterface, ToArrayInterface, Key
 
     public function __construct(private int $publisherId, PublishedMessage ...$messages)
     {
-        $this->messages = $messages;
+        $this->messages = array_values($messages);
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Request/PublishRequestV2.php
+++ b/src/Request/PublishRequestV2.php
@@ -23,7 +23,7 @@ class PublishRequestV2 implements ToStreamBufferInterface, ToArrayInterface, Key
 
     public function __construct(private int $publisherId, PublishedMessageV2 ...$messages)
     {
-        $this->messages = $messages;
+        $this->messages = array_values($messages);
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Request/TuneRequestV1.php
+++ b/src/Request/TuneRequestV1.php
@@ -14,6 +14,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
 
+/** @phpstan-consistent-constructor */
 class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, KeyVersionInterface
 {
     use V1Trait;
@@ -35,11 +36,11 @@ class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterfac
             ->addUInt32($this->heartbeat);
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
-        return new self($buffer->getUint32(), $buffer->getUint32());
+        return new static($buffer->getUint32(), $buffer->getUint32());
     }
 
     public function getFrameMax(): int

--- a/src/Response/CloseResponseV1.php
+++ b/src/Response/CloseResponseV1.php
@@ -25,12 +25,12 @@ class CloseResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -39,13 +39,13 @@ class ConsumerUpdateQueryV1 implements
         return $this->active;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         $subscriptionId = $buffer->getUint8();
         $active = $buffer->getUint8() === 1;
-        $object = new self($subscriptionId, $active);
+        $object = new static($subscriptionId, $active);
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/CreateResponseV1.php
+++ b/src/Response/CreateResponseV1.php
@@ -25,12 +25,12 @@ class CreateResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -25,12 +25,12 @@ class CreateSuperStreamResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/CreditResponseV1.php
+++ b/src/Response/CreditResponseV1.php
@@ -21,10 +21,10 @@ class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
     private int $responseCode;
     private int $subscriptionId;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->responseCode = $buffer->getUint16();
         $object->subscriptionId = $buffer->getUInt8();
         return $object;

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -25,12 +25,12 @@ class DeclarePublisherResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -25,12 +25,12 @@ class DeletePublisherResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/DeleteStreamResponseV1.php
+++ b/src/Response/DeleteStreamResponseV1.php
@@ -25,12 +25,12 @@ class DeleteStreamResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -25,12 +25,12 @@ class DeleteSuperStreamResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -32,7 +32,7 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
         return $this->chunkBytes;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         $key = $buffer->getUint16();
         $version = $buffer->getUint16();
@@ -45,7 +45,7 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
         }
 
         $chunkBytes = $buffer->getRemainingBytes();
-        return new self($subscriptionId, $chunkBytes);
+        return new static($subscriptionId, $chunkBytes);
     }
 
     /** @param array<string, mixed> $data */

--- a/src/Response/ExchangeCommandVersionsResponseV1.php
+++ b/src/Response/ExchangeCommandVersionsResponseV1.php
@@ -41,14 +41,14 @@ class ExchangeCommandVersionsResponseV1 implements
         return $this->commands;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
         $commands = $buffer->getObjectArray(CommandVersion::class);
 
-        $object = new self($commands);
+        $object = new static($commands);
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/MetadataResponseV1.php
+++ b/src/Response/MetadataResponseV1.php
@@ -53,7 +53,7 @@ class MetadataResponseV1 implements
         return $this->streamMetadata;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -62,7 +62,7 @@ class MetadataResponseV1 implements
         $brokers = $buffer->getObjectArray(Broker::class);
         $streamMetadata = $buffer->getObjectArray(StreamMetadata::class);
 
-        $object = new self($brokers, $streamMetadata);
+        $object = new static($brokers, $streamMetadata);
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -32,12 +32,12 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
         return $this->stream;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $code = $buffer->getUint16();
         $stream = $buffer->getString();
-        return new self($code, $stream);
+        return new static($code, $stream);
     }
 
     /** @param array<string, mixed> $data */

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -52,7 +52,7 @@ class OpenResponseV1 implements
         return $object;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -60,7 +60,7 @@ class OpenResponseV1 implements
 
         self::isResponseCodeOk($buffer->getUint16());
 
-        $object = new self(...$buffer->getObjectArray(KeyValue::class));
+        $object = new static(...$buffer->getObjectArray(KeyValue::class));
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -41,7 +41,7 @@ class PartitionsResponseV1 implements
         return $this->streams;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -50,7 +50,7 @@ class PartitionsResponseV1 implements
 
         $streams = $buffer->getStringArray();
 
-        $object = new self($streams);
+        $object = new static($streams);
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -31,7 +31,7 @@ class PeerPropertiesResponseV1 implements
 
     public function __construct(KeyValue ...$peerProperty)
     {
-        $this->peerProperty = $peerProperty;
+        $this->peerProperty = array_values($peerProperty);
     }
 
     /** @return array<int, KeyValue> */
@@ -57,7 +57,7 @@ class PeerPropertiesResponseV1 implements
         return $object;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -65,6 +65,6 @@ class PeerPropertiesResponseV1 implements
 
         self::isResponseCodeOk($buffer->getUint16());
 
-        return new self(...$buffer->getObjectArray(KeyValue::class));
+        return new static(...$buffer->getObjectArray(KeyValue::class));
     }
 }

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -23,7 +23,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
 
     public function __construct(private int $publisherId, int ...$publishingIds)
     {
-        $this->publishingIds = $publishingIds;
+        $this->publishingIds = array_values($publishingIds);
     }
 
     public function getPublisherId(): int
@@ -37,7 +37,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
         return $this->publishingIds;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $publisherId = $buffer->getUint8();
@@ -46,7 +46,7 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
         for ($i = 0; $i < $count; $i++) {
             $publishingIds[] = $buffer->getUint64();
         }
-        return new self($publisherId, ...$publishingIds);
+        return new static($publisherId, ...$publishingIds);
     }
 
     /** @param array<string, mixed> $data */

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -24,7 +24,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
 
     public function __construct(private int $publisherId, PublishingError ...$errors)
     {
-        $this->errors = $errors;
+        $this->errors = array_values($errors);
     }
 
     public function getPublisherId(): int
@@ -38,7 +38,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
         return $this->errors;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $publisherId = $buffer->getUint8();
@@ -47,7 +47,7 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
         for ($i = 0; $i < $count; $i++) {
             $errors[] = PublishingError::fromStreamBuffer($buffer);
         }
-        return new self($publisherId, ...$errors);
+        return new static($publisherId, ...$errors);
     }
 
     /** @param array<string, mixed> $data */

--- a/src/Response/QueryOffsetResponseV1.php
+++ b/src/Response/QueryOffsetResponseV1.php
@@ -27,14 +27,14 @@ class QueryOffsetResponseV1 implements
 
     private int $offset = 0;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
         $offset = $buffer->getUint64();
 
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         $object->offset = $offset;
         return $object;

--- a/src/Response/QueryPublisherSequenceResponseV1.php
+++ b/src/Response/QueryPublisherSequenceResponseV1.php
@@ -27,14 +27,14 @@ class QueryPublisherSequenceResponseV1 implements
 
     private int $sequence = 0;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
         $sequence = $buffer->getUint64();
 
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         $object->sequence = $sequence;
         return $object;

--- a/src/Response/ResolveOffsetSpecResponseV1.php
+++ b/src/Response/ResolveOffsetSpecResponseV1.php
@@ -27,7 +27,7 @@ class ResolveOffsetSpecResponseV1 implements
 
     private int $offset = 0;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
@@ -35,7 +35,7 @@ class ResolveOffsetSpecResponseV1 implements
         $buffer->getUint16(); // OffsetType: 1 (first), 2 (last), 3 (next), 4 (offset), 5 (timestamp)
         $offset = $buffer->getUint64();
 
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         $object->offset = $offset;
         return $object;

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -41,7 +41,7 @@ class RouteResponseV1 implements
         return $this->streams;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -50,7 +50,7 @@ class RouteResponseV1 implements
 
         $streams = $buffer->getStringArray();
 
-        $object = new self($streams);
+        $object = new static($streams);
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -25,7 +25,7 @@ class SaslAuthenticateResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -33,7 +33,7 @@ class SaslAuthenticateResponseV1 implements
 
         self::isResponseCodeOk($buffer->getUint16());
 
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -49,7 +49,7 @@ class SaslHandshakeResponseV1 implements
         return KeyEnum::SASL_HANDSHAKE_RESPONSE->value;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -57,7 +57,7 @@ class SaslHandshakeResponseV1 implements
 
         self::isResponseCodeOk($buffer->getUint16());
 
-        $object = new self($buffer->getStringArray());
+        $object = new static($buffer->getStringArray());
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/StreamStatsResponseV1.php
+++ b/src/Response/StreamStatsResponseV1.php
@@ -42,7 +42,7 @@ class StreamStatsResponseV1 implements
         return $this->stats;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
 
@@ -55,7 +55,7 @@ class StreamStatsResponseV1 implements
 
         $stats = $buffer->getObjectArray(Statistic::class);
 
-        $object = new self($stats);
+        $object = new static($stats);
         $object->withCorrelationId($correlationId);
 
         return $object;

--- a/src/Response/SubscribeResponseV1.php
+++ b/src/Response/SubscribeResponseV1.php
@@ -25,12 +25,12 @@ class SubscribeResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/Response/UnsubscribeResponseV1.php
+++ b/src/Response/UnsubscribeResponseV1.php
@@ -25,12 +25,12 @@ class UnsubscribeResponseV1 implements
     use CommandTrait;
     use V1Trait;
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
-        $object = new self();
+        $object = new static();
         $object->withCorrelationId($correlationId);
         return $object;
     }

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -401,7 +401,11 @@ class StreamConnection
             return null;
         }
 
-        $size = unpack('N', $sizeData)[1];
+        $sizeUnpacked = unpack('N', $sizeData);
+        if ($sizeUnpacked === false) {
+            throw new \RuntimeException('Failed to unpack frame size');
+        }
+        $size = $sizeUnpacked[1];
 
         $frameData = $this->readBytes($size);
         if ($frameData === null) {

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -34,9 +34,9 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
         return $this->port;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new self(
+        return new static(
             $buffer->getUint16(),
             $buffer->getString(),
             $buffer->getUint32()

--- a/src/VO/CommandVersion.php
+++ b/src/VO/CommandVersion.php
@@ -36,9 +36,9 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
         return $this->maxVersion;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new self(
+        return new static(
             $buffer->getUint16(),
             $buffer->getUint16(),
             $buffer->getUint16()

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -35,9 +35,9 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, To
             ->addString($this->value);
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new self($buffer->getString(), $buffer->getString());
+        return new static($buffer->getString(), $buffer->getString());
     }
 
     /** @return array<string, string|null> */

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -29,7 +29,7 @@ class PublishingError implements ToArrayInterface, FromArrayInterface
 
     public static function fromStreamBuffer(ReadBuffer $buffer): self
     {
-        return new self($buffer->getUint64(), $buffer->getUint16());
+        return new static($buffer->getUint64(), $buffer->getUint16());
     }
 
     /** @return array<string, int> */

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -35,9 +35,9 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, T
             ->addInt64($this->value);
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new self($buffer->getString(), $buffer->getInt64());
+        return new static($buffer->getString(), $buffer->getInt64());
     }
 
     /** @return array<string, int|string> */

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -42,7 +42,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
         return $this->replicasReferences;
     }
 
-    public static function fromStreamBuffer(ReadBuffer $buffer): ?object
+    public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
         $streamName = $buffer->getString();
         $responseCode = $buffer->getUint16();
@@ -54,7 +54,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
             $replicasReferences[] = $buffer->getUint16();
         }
 
-        return new self($streamName, $responseCode, $leaderReference, $replicasReferences);
+        return new static($streamName, $responseCode, $leaderReference, $replicasReferences);
     }
 
     /** @return array<string, mixed> */

--- a/tests/E2E/CloseTest.php
+++ b/tests/E2E/CloseTest.php
@@ -9,6 +9,7 @@ use CrazyGoat\RabbitStream\Request\OpenRequest;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesToStreamBufferV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
@@ -46,6 +47,7 @@ class CloseTest extends TestCase
         $connection->readMessage();
 
         $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
         $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
 
         $connection->sendMessage(new OpenRequest('/'));

--- a/tests/E2E/ResolveOffsetSpecE2ETest.php
+++ b/tests/E2E/ResolveOffsetSpecE2ETest.php
@@ -52,6 +52,9 @@ class ResolveOffsetSpecE2ETest extends TestCase
             $connection->readMessage();
 
             $tune = $connection->readMessage();
+            if (!$tune instanceof TuneRequestV1) {
+                throw new \RuntimeException('Expected TuneRequestV1');
+            }
             $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
 
             $connection->sendMessage(new OpenRequest('/'));

--- a/tests/Request/TuneRequestV1Test.php
+++ b/tests/Request/TuneRequestV1Test.php
@@ -43,6 +43,7 @@ class TuneRequestV1Test extends TestCase
         $original = new TuneRequestV1(65536, 30);
         $bytes = $original->toStreamBuffer()->getContents();
         $decoded = TuneRequestV1::fromStreamBuffer(new ReadBuffer($bytes));
+        $this->assertInstanceOf(TuneRequestV1::class, $decoded);
 
         $this->assertSame($original->getFrameMax(), $decoded->getFrameMax());
         $this->assertSame($original->getHeartbeat(), $decoded->getHeartbeat());

--- a/tests/Response/ConsumerUpdateQueryV1Test.php
+++ b/tests/Response/ConsumerUpdateQueryV1Test.php
@@ -35,6 +35,7 @@ class ConsumerUpdateQueryV1Test extends TestCase
             . pack('C', 0);
 
         $response = ConsumerUpdateQueryV1::fromStreamBuffer(new ReadBuffer($raw));
+        $this->assertInstanceOf(ConsumerUpdateQueryV1::class, $response);
 
         $this->assertFalse($response->isActive());
     }

--- a/tests/Response/PublishConfirmResponseV1Test.php
+++ b/tests/Response/PublishConfirmResponseV1Test.php
@@ -36,6 +36,7 @@ class PublishConfirmResponseV1Test extends TestCase
             . pack('J', 3);
 
         $response = PublishConfirmResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+        $this->assertInstanceOf(PublishConfirmResponseV1::class, $response);
 
         $this->assertSame(1, $response->getPublisherId());
         $this->assertSame([1, 2, 3], $response->getPublishingIds());
@@ -49,6 +50,7 @@ class PublishConfirmResponseV1Test extends TestCase
             . pack('N', 0);
 
         $response = PublishConfirmResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+        $this->assertInstanceOf(PublishConfirmResponseV1::class, $response);
 
         $this->assertSame(2, $response->getPublisherId());
         $this->assertSame([], $response->getPublishingIds());

--- a/tests/Response/PublishErrorResponseV1Test.php
+++ b/tests/Response/PublishErrorResponseV1Test.php
@@ -39,6 +39,7 @@ class PublishErrorResponseV1Test extends TestCase
             . pack('J', 20) . pack('n', 0x0002);
 
         $response = PublishErrorResponseV1::fromStreamBuffer(new ReadBuffer($raw));
+        $this->assertInstanceOf(PublishErrorResponseV1::class, $response);
 
         $this->assertSame(1, $response->getPublisherId());
         $errors = $response->getErrors();

--- a/tests/Serializer/PhpBinarySerializerTest.php
+++ b/tests/Serializer/PhpBinarySerializerTest.php
@@ -249,6 +249,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(SaslHandshakeResponseV1::class, $deserialized);
+        $this->assertInstanceOf(SaslHandshakeResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -266,6 +267,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(PeerPropertiesResponseV1::class, $deserialized);
+        $this->assertInstanceOf(PeerPropertiesResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -281,6 +283,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(SaslAuthenticateResponseV1::class, $deserialized);
+        $this->assertInstanceOf(SaslAuthenticateResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -296,6 +299,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(OpenResponseV1::class, $deserialized);
+        $this->assertInstanceOf(OpenResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -310,6 +314,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(CreateResponseV1::class, $deserialized);
+        $this->assertInstanceOf(CreateResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -324,6 +329,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(DeleteStreamResponseV1::class, $deserialized);
+        $this->assertInstanceOf(DeleteStreamResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -347,6 +353,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(MetadataResponseV1::class, $deserialized);
+        $this->assertInstanceOf(MetadataResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -361,6 +368,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(DeclarePublisherResponseV1::class, $deserialized);
+        $this->assertInstanceOf(DeclarePublisherResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -375,6 +383,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(DeletePublisherResponseV1::class, $deserialized);
+        $this->assertInstanceOf(DeletePublisherResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -389,6 +398,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(SubscribeResponseV1::class, $deserialized);
+        $this->assertInstanceOf(SubscribeResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -403,6 +413,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(UnsubscribeResponseV1::class, $deserialized);
+        $this->assertInstanceOf(UnsubscribeResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 
@@ -417,6 +428,7 @@ class PhpBinarySerializerTest extends TestCase
         $expected = ResponseBuilder::fromResponseBuffer(new ReadBuffer($raw));
 
         $this->assertInstanceOf(CloseResponseV1::class, $deserialized);
+        $this->assertInstanceOf(CloseResponseV1::class, $expected);
         $this->assertSame($expected->getCorrelationId(), $deserialized->getCorrelationId());
     }
 }


### PR DESCRIPTION
## Summary
- Bumps PHPStan from level 6 to level 7
- Fixed 77 errors across 51 files
- Added `unpack()` false checks in ReadBuffer, AmqpDecoder, StreamConnection
- Changed `FromStreamBufferInterface::fromStreamBuffer()` return type to `?static`
- Added `@template` to `ReadBuffer::getObjectArray()` for type-safe returns
- Re-indexed variadic arrays with `array_values()`
- Added `assertInstanceOf` in tests before accessing typed methods

Closes #81