### PR TITLE
feat: bump PHPStan to level 8, all violations fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 7)
+    name: PHPStan (level 8)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     paths:
         - src
         - tests

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -36,7 +36,7 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
     {
         self::validateKeyVersion($buffer->getUint16(), $buffer->getUint16());
         $code = $buffer->getUint16();
-        $stream = $buffer->getString();
+        $stream = $buffer->getString() ?? '';
         return new static($code, $stream);
     }
 

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -48,7 +48,7 @@ class PartitionsResponseV1 implements
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
 
-        $streams = $buffer->getStringArray();
+        $streams = array_map(fn(?string $s): string => $s ?? '', $buffer->getStringArray());
 
         $object = new static($streams);
         $object->withCorrelationId($correlationId);

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -48,7 +48,7 @@ class RouteResponseV1 implements
         $correlationId = $buffer->getUint32();
         self::isResponseCodeOk($buffer->getUint16());
 
-        $streams = $buffer->getStringArray();
+        $streams = array_map(fn(?string $s): string => $s ?? '', $buffer->getStringArray());
 
         $object = new static($streams);
         $object->withCorrelationId($correlationId);

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -45,14 +45,20 @@ class ResponseBuilder
         $version = $responseBuffer->getUint16();
 
         $responseBuffer->rewind();
-        return match ($version) {
+        $result = match ($version) {
             1 => self::getV1($command, $responseBuffer),
             2 => self::getV2($command, $responseBuffer),
             default => throw new \Exception('Unexpected match value'),
         };
+
+        if ($result === null) {
+            throw new \Exception('Failed to deserialize response for command: ' . $command->name);
+        }
+
+        return $result;
     }
 
-    private static function getV1(KeyEnum $command, ReadBuffer $responseBuffer): object
+    private static function getV1(KeyEnum $command, ReadBuffer $responseBuffer): ?object
     {
         return match ($command) {
             KeyEnum::DECLARE_PUBLISHER_RESPONSE => DeclarePublisherResponseV1::fromStreamBuffer($responseBuffer),
@@ -92,7 +98,7 @@ class ResponseBuilder
         };
     }
 
-    private static function getV2(KeyEnum $command, ReadBuffer $responseBuffer): object
+    private static function getV2(KeyEnum $command, ReadBuffer $responseBuffer): ?object
     {
         return match ($command) {
             KeyEnum::DELIVER => DeliverResponseV1::fromStreamBuffer($responseBuffer),

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -175,6 +175,10 @@ class StreamConnection
             }
         }
 
+        if (!$this->socket instanceof \Socket) {
+            throw new \RuntimeException("Cannot write: socket is not connected");
+        }
+
         $written = socket_write($this->socket, $frame, strlen($frame));
         if ($written === false) {
             throw new \RuntimeException(
@@ -304,6 +308,9 @@ class StreamConnection
 
             case KeyEnum::PUBLISH_CONFIRM->value:
                 $confirm = PublishConfirmResponseV1::fromStreamBuffer($frame);
+                if (!$confirm instanceof PublishConfirmResponseV1) {
+                    throw new \RuntimeException('Failed to deserialize PublishConfirm frame');
+                }
                 $publisherId = $confirm->getPublisherId();
                 if (isset($this->publisherCallbacks[$publisherId])) {
                     ($this->publisherCallbacks[$publisherId]['onConfirm'])($confirm->getPublishingIds());
@@ -312,6 +319,9 @@ class StreamConnection
 
             case KeyEnum::PUBLISH_ERROR->value:
                 $error = PublishErrorResponseV1::fromStreamBuffer($frame);
+                if (!$error instanceof PublishErrorResponseV1) {
+                    throw new \RuntimeException('Failed to deserialize PublishError frame');
+                }
                 $publisherId = $error->getPublisherId();
                 if (isset($this->publisherCallbacks[$publisherId])) {
                     ($this->publisherCallbacks[$publisherId]['onError'])($error->getErrors());
@@ -320,6 +330,9 @@ class StreamConnection
 
             case KeyEnum::DELIVER->value:
                 $deliver = DeliverResponseV1::fromStreamBuffer($frame);
+                if (!$deliver instanceof DeliverResponseV1) {
+                    throw new \RuntimeException('Failed to deserialize Deliver frame');
+                }
                 $subscriptionId = $deliver->getSubscriptionId();
                 if (isset($this->subscriberCallbacks[$subscriptionId])) {
                     ($this->subscriberCallbacks[$subscriptionId])($deliver);
@@ -360,6 +373,9 @@ class StreamConnection
 
             case KeyEnum::CONSUMER_UPDATE->value:
                 $query = ConsumerUpdateQueryV1::fromStreamBuffer($frame);
+                if (!$query instanceof ConsumerUpdateQueryV1) {
+                    throw new \RuntimeException('Failed to deserialize ConsumerUpdate frame');
+                }
                 $offsetType = 1;
                 $offset = 0;
                 if ($this->consumerUpdateCallback instanceof \Closure) {
@@ -419,6 +435,10 @@ class StreamConnection
 
     private function readBytes(int $length): ?string
     {
+        if (!$this->socket instanceof \Socket) {
+            throw new \RuntimeException("Cannot read: socket is not connected");
+        }
+
         $data = '';
         $remaining = $length;
 

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -38,7 +38,7 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
     {
         return new static(
             $buffer->getUint16(),
-            $buffer->getString(),
+            $buffer->getString() ?? '',
             $buffer->getUint32()
         );
     }

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -37,7 +37,7 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, To
 
     public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new static($buffer->getString(), $buffer->getString());
+        return new static($buffer->getString() ?? '', $buffer->getString());
     }
 
     /** @return array<string, string|null> */

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -37,7 +37,7 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, T
 
     public static function fromStreamBuffer(ReadBuffer $buffer): ?static
     {
-        return new static($buffer->getString(), $buffer->getInt64());
+        return new static($buffer->getString() ?? '', $buffer->getInt64());
     }
 
     /** @return array<string, int|string> */

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -54,7 +54,7 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
             $replicasReferences[] = $buffer->getUint16();
         }
 
-        return new static($streamName, $responseCode, $leaderReference, $replicasReferences);
+        return new static($streamName ?? '', $responseCode, $leaderReference, $replicasReferences);
     }
 
     /** @return array<string, mixed> */

--- a/tests/Client/ConnectionTest.php
+++ b/tests/Client/ConnectionTest.php
@@ -127,6 +127,7 @@ class ConnectionTest extends TestCase
     {
         $reflection = new \ReflectionClass(Connection::class);
         $constructor = $reflection->getConstructor();
+        $this->assertNotNull($constructor, 'Connection class must have a constructor');
 
         $connection = $reflection->newInstanceWithoutConstructor();
         $constructor->invoke($connection, $mock);

--- a/tests/Client/ProducerTest.php
+++ b/tests/Client/ProducerTest.php
@@ -117,6 +117,7 @@ class ProducerTest extends TestCase
     {
         $connection = $this->createMock(StreamConnection::class);
 
+        /** @var array{onConfirm: callable, onError: callable}|null $registeredCallbacks */
         $registeredCallbacks = null;
         $connection->expects($this->once())
             ->method('registerPublisher')
@@ -135,6 +136,7 @@ class ProducerTest extends TestCase
         $connection->expects($this->once())
             ->method('readLoop')
             ->willReturnCallback(function () use (&$registeredCallbacks): void {
+                $this->assertNotNull($registeredCallbacks, 'registerPublisher callback must have been called');
                 ($registeredCallbacks['onConfirm'])([0]);
             });
 
@@ -221,6 +223,7 @@ class ProducerTest extends TestCase
     {
         $connection = $this->createMock(StreamConnection::class);
 
+        /** @var array{onConfirm: callable, onError: callable}|null $registeredCallbacks */
         $registeredCallbacks = null;
         $connection->expects($this->once())
             ->method('registerPublisher')
@@ -236,6 +239,7 @@ class ProducerTest extends TestCase
             ->method('readLoop')
             ->willReturnCallback(function () use (&$registeredCallbacks, &$readLoopCalled): void {
                 $readLoopCalled = true;
+                $this->assertNotNull($registeredCallbacks, 'registerPublisher callback must have been called');
                 ($registeredCallbacks['onConfirm'])([0, 1, 2]);
             });
 

--- a/tests/E2E/ConsumerTest.php
+++ b/tests/E2E/ConsumerTest.php
@@ -53,6 +53,7 @@ class ConsumerTest extends TestCase
 
     public function testReadReturnsEmptyOnTimeout(): void
     {
+        $this->assertNotNull($this->connection);
         $consumer = $this->connection->createConsumer($this->streamName, OffsetSpec::first());
 
         $messages = $consumer->read(timeout: 1);
@@ -64,6 +65,7 @@ class ConsumerTest extends TestCase
 
     public function testProduceAndConsumeWithRead(): void
     {
+        $this->assertNotNull($this->connection);
         $producer = $this->connection->createProducer($this->streamName);
         $producer->sendBatch([$this->amqp('hello'), $this->amqp('world'), $this->amqp('foo')]);
         $producer->waitForConfirms(timeout: 5);
@@ -90,6 +92,7 @@ class ConsumerTest extends TestCase
 
     public function testReadOneReturnsSingleMessage(): void
     {
+        $this->assertNotNull($this->connection);
         $producer = $this->connection->createProducer($this->streamName);
         $producer->sendBatch([$this->amqp('msg1'), $this->amqp('msg2')]);
         $producer->waitForConfirms(timeout: 5);
@@ -111,6 +114,7 @@ class ConsumerTest extends TestCase
 
     public function testStoreAndQueryOffset(): void
     {
+        $this->assertNotNull($this->connection);
         $producer = $this->connection->createProducer($this->streamName);
         $producer->send($this->amqp('offset-test'));
         $producer->waitForConfirms(timeout: 5);

--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -36,6 +36,7 @@ class ProducerTest extends TestCase
 
     public function testSendAndWaitForConfirms(): void
     {
+        $this->assertNotNull($this->connection);
         $confirmed = [];
         $producer = $this->connection->createProducer(
             $this->streamName,
@@ -55,6 +56,7 @@ class ProducerTest extends TestCase
 
     public function testSendBatchAndWaitForConfirms(): void
     {
+        $this->assertNotNull($this->connection);
         $confirmed = [];
         $producer = $this->connection->createProducer(
             $this->streamName,
@@ -76,6 +78,7 @@ class ProducerTest extends TestCase
 
     public function testGetLastPublishingId(): void
     {
+        $this->assertNotNull($this->connection);
         $producer = $this->connection->createProducer($this->streamName);
 
         $this->assertEquals(-1, $producer->getLastPublishingId());
@@ -91,6 +94,7 @@ class ProducerTest extends TestCase
 
     public function testQuerySequenceForNamedProducer(): void
     {
+        $this->assertNotNull($this->connection);
         $producer = $this->connection->createProducer(
             $this->streamName,
             name: 'test-producer-ref'


### PR DESCRIPTION
## Summary
- Bumps PHPStan from level 7 to level 8
- Fixed 31 errors across 13 files
- Added null coalescing for `getString()` returns in VOs and Responses
- Changed `ResponseBuilder::getV1()/getV2()` return type to `?object`
- Added null/instanceof guards in `StreamConnection` for socket and parsed responses
- Added `assertNotNull` in E2E and unit tests

Closes #82