### PR TITLE
feat: bump PHPStan to level 9 (max)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./vendor/bin/rector process --dry-run
 
   static-analysis:
-    name: PHPStan (level 8)
+    name: PHPStan (level 9)
     needs: [check-actor, rector-check]
     if: needs.check-actor.outputs.allowed == 'true'
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 8
+    level: 9
     paths:
         - src
         - tests

--- a/src/Client/AmqpDecoder.php
+++ b/src/Client/AmqpDecoder.php
@@ -126,7 +126,7 @@ class AmqpDecoder
                     break;
 
                 case 0x73: // Properties
-                    $sections['properties'] = self::parsePropertiesList($value);
+                    $sections['properties'] = self::parsePropertiesList(is_array($value) ? $value : []);
                     break;
 
                 case 0x74: // ApplicationProperties
@@ -135,7 +135,8 @@ class AmqpDecoder
 
                 case 0x75: // Data (body)
                     if (is_string($value)) {
-                        $sections['body'] .= $value;
+                        $currentBody = $sections['body'];
+                        $sections['body'] = (is_string($currentBody) ? $currentBody : '') . $value;
                     }
                     break;
 
@@ -215,13 +216,25 @@ class AmqpDecoder
         return $result;
     }
 
+    private static function unpackInt(string $format, string $data, string $context): int
+    {
+        $val = self::safeUnpack($format, $data, $context)[1];
+        return is_scalar($val) ? (int) $val : 0;
+    }
+
+    private static function unpackFloat(string $format, string $data, string $context): float
+    {
+        $val = self::safeUnpack($format, $data, $context)[1];
+        return is_scalar($val) ? (float) $val : 0.0;
+    }
+
     /** @return array{0: int, 1: int} */
     private static function readInt8(string $data, int $position): array
     {
         if ($position >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int8');
         }
-        $value = self::safeUnpack('c', $data[$position], 'int8')[1];
+        $value = self::unpackInt('c', $data[$position], 'int8');
         return [$value, $position + 1];
     }
 
@@ -231,7 +244,7 @@ class AmqpDecoder
         if ($position + 1 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint16');
         }
-        $value = self::safeUnpack('n', substr($data, $position, 2), 'uint16')[1];
+        $value = self::unpackInt('n', substr($data, $position, 2), 'uint16');
         return [$value, $position + 2];
     }
 
@@ -241,7 +254,7 @@ class AmqpDecoder
         if ($position + 1 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int16');
         }
-        $value = self::safeUnpack('s', strrev(substr($data, $position, 2)), 'int16')[1];
+        $value = self::unpackInt('s', strrev(substr($data, $position, 2)), 'int16');
         return [$value, $position + 2];
     }
 
@@ -251,7 +264,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint32');
         }
-        $value = self::safeUnpack('N', substr($data, $position, 4), 'uint32')[1];
+        $value = self::unpackInt('N', substr($data, $position, 4), 'uint32');
         // Handle unsigned 32-bit values > PHP_INT_MAX
         if ($value < 0) {
             $value += 4294967296;
@@ -265,7 +278,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int32');
         }
-        $value = self::safeUnpack('l', strrev(substr($data, $position, 4)), 'int32')[1];
+        $value = self::unpackInt('l', strrev(substr($data, $position, 4)), 'int32');
         return [$value, $position + 4];
     }
 
@@ -275,7 +288,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading float');
         }
-        $value = self::safeUnpack('f', strrev(substr($data, $position, 4)), 'float')[1];
+        $value = self::unpackFloat('f', strrev(substr($data, $position, 4)), 'float');
         return [$value, $position + 4];
     }
 
@@ -285,8 +298,8 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading uint64');
         }
-        $high = self::safeUnpack('N', substr($data, $position, 4), 'uint64 high')[1];
-        $low = self::safeUnpack('N', substr($data, $position + 4, 4), 'uint64 low')[1];
+        $high = self::unpackInt('N', substr($data, $position, 4), 'uint64 high');
+        $low = self::unpackInt('N', substr($data, $position + 4, 4), 'uint64 low');
         // Handle as string for large values
         if ($high < 0) {
             $high += 4294967296;
@@ -304,7 +317,7 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading int64');
         }
-        $value = self::safeUnpack('q', strrev(substr($data, $position, 8)), 'int64')[1];
+        $value = self::unpackInt('q', strrev(substr($data, $position, 8)), 'int64');
         return [$value, $position + 8];
     }
 
@@ -314,7 +327,7 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading double');
         }
-        $value = self::safeUnpack('d', strrev(substr($data, $position, 8)), 'double')[1];
+        $value = self::unpackFloat('d', strrev(substr($data, $position, 8)), 'double');
         return [$value, $position + 8];
     }
 
@@ -325,7 +338,7 @@ class AmqpDecoder
             throw new \RuntimeException('Unexpected end of data reading timestamp');
         }
         // Timestamp is milliseconds since Unix epoch (int64)
-        $value = self::safeUnpack('q', strrev(substr($data, $position, 8)), 'timestamp')[1];
+        $value = self::unpackInt('q', strrev(substr($data, $position, 8)), 'timestamp');
         return [$value, $position + 8];
     }
 
@@ -337,12 +350,12 @@ class AmqpDecoder
         }
         $bytes = substr($data, $position, 16);
         // Format as UUID string: 8-4-4-4-12 hex digits
-        $p1 = self::safeUnpack('N', substr($bytes, 0, 4), 'uuid part1')[1];
-        $p2 = self::safeUnpack('n', substr($bytes, 4, 2), 'uuid part2')[1];
-        $p3 = self::safeUnpack('n', substr($bytes, 6, 2), 'uuid part3')[1];
-        $p4 = self::safeUnpack('n', substr($bytes, 8, 2), 'uuid part4')[1];
-        $p5a = self::safeUnpack('N', substr($bytes, 10, 4), 'uuid part5a')[1];
-        $p5b = self::safeUnpack('n', substr($bytes, 14, 2), 'uuid part5b')[1];
+        $p1 = self::unpackInt('N', substr($bytes, 0, 4), 'uuid part1');
+        $p2 = self::unpackInt('n', substr($bytes, 4, 2), 'uuid part2');
+        $p3 = self::unpackInt('n', substr($bytes, 6, 2), 'uuid part3');
+        $p4 = self::unpackInt('n', substr($bytes, 8, 2), 'uuid part4');
+        $p5a = self::unpackInt('N', substr($bytes, 10, 4), 'uuid part5a');
+        $p5b = self::unpackInt('n', substr($bytes, 14, 2), 'uuid part5b');
         $value = sprintf(
             '%08x-%04x-%04x-%04x-%012x',
             $p1,
@@ -385,7 +398,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading binary32 length');
         }
-        $length = self::safeUnpack('N', substr($data, $position, 4), 'binary32 length')[1];
+        $length = self::unpackInt('N', substr($data, $position, 4), 'binary32 length');
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -416,7 +429,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading string32 length');
         }
-        $length = self::safeUnpack('N', substr($data, $position, 4), 'string32 length')[1];
+        $length = self::unpackInt('N', substr($data, $position, 4), 'string32 length');
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -447,7 +460,7 @@ class AmqpDecoder
         if ($position + 3 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading symbol32 length');
         }
-        $length = self::safeUnpack('N', substr($data, $position, 4), 'symbol32 length')[1];
+        $length = self::unpackInt('N', substr($data, $position, 4), 'symbol32 length');
         if ($length < 0) {
             $length += 4294967296;
         }
@@ -489,11 +502,11 @@ class AmqpDecoder
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading list32 header');
         }
-        $size = self::safeUnpack('N', substr($data, $position, 4), 'list32 size')[1];
+        $size = self::unpackInt('N', substr($data, $position, 4), 'list32 size');
         if ($size < 0) {
             $size += 4294967296;
         }
-        $count = self::safeUnpack('N', substr($data, $position + 4, 4), 'list32 count')[1];
+        $count = self::unpackInt('N', substr($data, $position + 4, 4), 'list32 count');
         if ($count < 0) {
             $count += 4294967296;
         }
@@ -512,7 +525,7 @@ class AmqpDecoder
         return [$list, $position];
     }
 
-    /** @return array{0: array<mixed, mixed>, 1: int} */
+    /** @return array{0: array<string|int, mixed>, 1: int} */
     private static function readMap8(string $data, int $position): array
     {
         if ($position + 1 >= strlen($data)) {
@@ -534,23 +547,24 @@ class AmqpDecoder
                 throw new \RuntimeException('Map8 missing value for key');
             }
             [$value, $position] = self::decodeValue($data, $position);
-            $map[$key] = $value;
+            $mapKey = is_int($key) ? $key : (is_scalar($key) ? (string) $key : '');
+            $map[$mapKey] = $value;
         }
 
         return [$map, $position];
     }
 
-    /** @return array{0: array<mixed, mixed>, 1: int} */
+    /** @return array{0: array<string|int, mixed>, 1: int} */
     private static function readMap32(string $data, int $position): array
     {
         if ($position + 7 >= strlen($data)) {
             throw new \RuntimeException('Unexpected end of data reading map32 header');
         }
-        $size = self::safeUnpack('N', substr($data, $position, 4), 'map32 size')[1];
+        $size = self::unpackInt('N', substr($data, $position, 4), 'map32 size');
         if ($size < 0) {
             $size += 4294967296;
         }
-        $count = self::safeUnpack('N', substr($data, $position + 4, 4), 'map32 count')[1];
+        $count = self::unpackInt('N', substr($data, $position + 4, 4), 'map32 count');
         if ($count < 0) {
             $count += 4294967296;
         }
@@ -568,7 +582,8 @@ class AmqpDecoder
                 throw new \RuntimeException('Map32 missing value for key');
             }
             [$value, $position] = self::decodeValue($data, $position);
-            $map[$key] = $value;
+            $mapKey = is_int($key) ? $key : (is_scalar($key) ? (string) $key : '');
+            $map[$mapKey] = $value;
         }
 
         return [$map, $position];

--- a/src/Client/AmqpMessageDecoder.php
+++ b/src/Client/AmqpMessageDecoder.php
@@ -12,13 +12,27 @@ class AmqpMessageDecoder
     public static function decode(ChunkEntry $entry): Message
     {
         $sections = AmqpDecoder::decodeMessage($entry->getData());
+
+        $rawBody = $sections['body'] ?? null;
+        if (is_array($rawBody)) {
+            $body = array_values($rawBody);
+        } elseif ($rawBody === null || is_scalar($rawBody)) {
+            $body = $rawBody;
+        } else {
+            $body = null;
+        }
+
+        $properties = $sections['properties'] ?? [];
+        $applicationProperties = $sections['applicationProperties'] ?? [];
+        $messageAnnotations = $sections['messageAnnotations'] ?? [];
+
         return new Message(
             offset: $entry->getOffset(),
             timestamp: $entry->getTimestamp(),
-            body: $sections['body'],
-            properties: $sections['properties'] ?? [],
-            applicationProperties: $sections['applicationProperties'] ?? [],
-            messageAnnotations: $sections['messageAnnotations'] ?? [],
+            body: $body,
+            properties: is_array($properties) ? $properties : [],
+            applicationProperties: is_array($applicationProperties) ? $applicationProperties : [],
+            messageAnnotations: is_array($messageAnnotations) ? $messageAnnotations : [],
         );
     }
 

--- a/src/Client/Message.php
+++ b/src/Client/Message.php
@@ -68,21 +68,25 @@ class Message
 
     public function getContentType(): ?string
     {
-        return $this->properties['content-type'] ?? null;
+        $value = $this->properties['content-type'] ?? null;
+        return is_scalar($value) ? (string) $value : null;
     }
 
     public function getSubject(): ?string
     {
-        return $this->properties['subject'] ?? null;
+        $value = $this->properties['subject'] ?? null;
+        return is_scalar($value) ? (string) $value : null;
     }
 
     public function getCreationTime(): ?int
     {
-        return $this->properties['creation-time'] ?? null;
+        $value = $this->properties['creation-time'] ?? null;
+        return is_scalar($value) ? (int) $value : null;
     }
 
     public function getGroupId(): ?string
     {
-        return $this->properties['group-id'] ?? null;
+        $value = $this->properties['group-id'] ?? null;
+        return is_scalar($value) ? (string) $value : null;
     }
 }

--- a/src/Response/CloseResponseV1.php
+++ b/src/Response/CloseResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class CloseResponseV1 implements
@@ -39,7 +40,7 @@ class CloseResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/ConsumerUpdateQueryV1.php
+++ b/src/Response/ConsumerUpdateQueryV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class ConsumerUpdateQueryV1 implements
@@ -53,8 +54,8 @@ class ConsumerUpdateQueryV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        $object = new static($data['subscriptionId'], $data['active']);
-        $object->withCorrelationId($data['correlationId']);
+        $object = new static(TypeCast::toInt($data['subscriptionId']), TypeCast::toBool($data['active']));
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/CreateResponseV1.php
+++ b/src/Response/CreateResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class CreateResponseV1 implements
@@ -39,7 +40,7 @@ class CreateResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/CreateSuperStreamResponseV1.php
+++ b/src/Response/CreateSuperStreamResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class CreateSuperStreamResponseV1 implements
@@ -39,7 +40,7 @@ class CreateSuperStreamResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/CreditResponseV1.php
+++ b/src/Response/CreditResponseV1.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
@@ -44,8 +45,8 @@ class CreditResponseV1 implements KeyVersionInterface, FromStreamBufferInterface
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->responseCode = $data['responseCode'];
-        $object->subscriptionId = $data['subscriptionId'];
+        $object->responseCode = TypeCast::toInt($data['responseCode']);
+        $object->subscriptionId = TypeCast::toInt($data['subscriptionId']);
         return $object;
     }
 

--- a/src/Response/DeclarePublisherResponseV1.php
+++ b/src/Response/DeclarePublisherResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class DeclarePublisherResponseV1 implements
@@ -39,7 +40,7 @@ class DeclarePublisherResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/DeletePublisherResponseV1.php
+++ b/src/Response/DeletePublisherResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class DeletePublisherResponseV1 implements
@@ -39,7 +40,7 @@ class DeletePublisherResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/DeleteStreamResponseV1.php
+++ b/src/Response/DeleteStreamResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class DeleteStreamResponseV1 implements
@@ -39,7 +40,7 @@ class DeleteStreamResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/DeleteSuperStreamResponseV1.php
+++ b/src/Response/DeleteSuperStreamResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class DeleteSuperStreamResponseV1 implements
@@ -39,7 +40,7 @@ class DeleteSuperStreamResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/DeliverResponseV1.php
+++ b/src/Response/DeliverResponseV1.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
@@ -51,7 +52,7 @@ class DeliverResponseV1 implements KeyVersionInterface, FromStreamBufferInterfac
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['subscriptionId'], $data['chunkBytes']);
+        return new static(TypeCast::toInt($data['subscriptionId']), TypeCast::toString($data['chunkBytes']));
     }
 
     public static function getKey(): int

--- a/src/Response/ExchangeCommandVersionsResponseV1.php
+++ b/src/Response/ExchangeCommandVersionsResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\CommandVersion;
 
 /** @phpstan-consistent-constructor */
@@ -57,16 +58,20 @@ class ExchangeCommandVersionsResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $commandsData = TypeCast::toArray($data['commands'] ?? []);
         $commands = array_map(
-            fn(array $c): \CrazyGoat\RabbitStream\VO\CommandVersion => new CommandVersion(
-                $c['key'],
-                $c['minVersion'],
-                $c['maxVersion']
-            ),
-            $data['commands']
+            function (mixed $c): CommandVersion {
+                $ca = is_array($c) ? $c : [];
+                return new CommandVersion(
+                    TypeCast::toInt($ca['key'] ?? 0),
+                    TypeCast::toInt($ca['minVersion'] ?? 0),
+                    TypeCast::toInt($ca['maxVersion'] ?? 0)
+                );
+            },
+            $commandsData
         );
         $object = new static($commands);
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/MetadataResponseV1.php
+++ b/src/Response/MetadataResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\Broker;
 use CrazyGoat\RabbitStream\VO\StreamMetadata;
 
@@ -71,21 +72,33 @@ class MetadataResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $brokersData = TypeCast::toArray($data['brokers'] ?? []);
         $brokers = array_map(
-            fn(array $b): \CrazyGoat\RabbitStream\VO\Broker => new Broker($b['reference'], $b['host'], $b['port']),
-            $data['brokers']
+            function (mixed $b): Broker {
+                $ba = is_array($b) ? $b : [];
+                return new Broker(
+                    TypeCast::toInt($ba['reference'] ?? 0),
+                    TypeCast::toString($ba['host'] ?? ''),
+                    TypeCast::toInt($ba['port'] ?? 0)
+                );
+            },
+            $brokersData
         );
+        $streamMetadataData = TypeCast::toArray($data['streamMetadata'] ?? []);
         $streamMetadata = array_map(
-            fn(array $s): \CrazyGoat\RabbitStream\VO\StreamMetadata => new StreamMetadata(
-                $s['stream'],
-                $s['responseCode'],
-                $s['leaderReference'],
-                $s['replicasReferences']
-            ),
-            $data['streamMetadata']
+            function (mixed $s): StreamMetadata {
+                $sa = is_array($s) ? $s : [];
+                return new StreamMetadata(
+                    TypeCast::toString($sa['stream'] ?? ''),
+                    TypeCast::toInt($sa['responseCode'] ?? 0),
+                    TypeCast::toInt($sa['leaderReference'] ?? 0),
+                    TypeCast::toIntArray($sa['replicasReferences'] ?? [])
+                );
+            },
+            $streamMetadataData
         );
         $object = new static($brokers, $streamMetadata);
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/MetadataUpdateResponseV1.php
+++ b/src/Response/MetadataUpdateResponseV1.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
@@ -43,7 +44,7 @@ class MetadataUpdateResponseV1 implements KeyVersionInterface, FromStreamBufferI
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['code'], $data['stream']);
+        return new static(TypeCast::toInt($data['code']), TypeCast::toString($data['stream']));
     }
 
     public static function getKey(): int

--- a/src/Response/OpenResponseV1.php
+++ b/src/Response/OpenResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
 /** @phpstan-consistent-constructor */
@@ -43,12 +44,19 @@ class OpenResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $propsData = TypeCast::toArray($data['connectionProperties'] ?? []);
         $properties = array_map(
-            fn(array $p): \CrazyGoat\RabbitStream\VO\KeyValue => new KeyValue($p['key'], $p['value']),
-            $data['connectionProperties']
+            function (mixed $p): KeyValue {
+                $pa = is_array($p) ? $p : [];
+                return new KeyValue(
+                    TypeCast::toString($pa['key'] ?? ''),
+                    TypeCast::toNullableString($pa['value'] ?? null)
+                );
+            },
+            $propsData
         );
         $object = new static(...$properties);
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/PartitionsResponseV1.php
+++ b/src/Response/PartitionsResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class PartitionsResponseV1 implements
@@ -59,8 +60,8 @@ class PartitionsResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        $object = new static($data['streams']);
-        $object->withCorrelationId($data['correlationId']);
+        $object = new static(TypeCast::toStringArray($data['streams'] ?? []));
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/PeerPropertiesResponseV1.php
+++ b/src/Response/PeerPropertiesResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\KeyValue;
 
 /** @phpstan-consistent-constructor */
@@ -48,12 +49,19 @@ class PeerPropertiesResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $propsData = TypeCast::toArray($data['properties'] ?? []);
         $properties = array_map(
-            fn(array $p): \CrazyGoat\RabbitStream\VO\KeyValue => new KeyValue($p['key'], $p['value']),
-            $data['properties']
+            function (mixed $p): KeyValue {
+                $pa = is_array($p) ? $p : [];
+                return new KeyValue(
+                    TypeCast::toString($pa['key'] ?? ''),
+                    TypeCast::toNullableString($pa['value'] ?? null)
+                );
+            },
+            $propsData
         );
         $object = new static(...$properties);
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/PublishConfirmResponseV1.php
+++ b/src/Response/PublishConfirmResponseV1.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferInterface, FromArrayInterface
@@ -52,7 +53,8 @@ class PublishConfirmResponseV1 implements KeyVersionInterface, FromStreamBufferI
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['publisherId'], ...$data['publishingIds']);
+        $publishingIds = TypeCast::toIntArray($data['publishingIds'] ?? []);
+        return new static(TypeCast::toInt($data['publisherId']), ...$publishingIds);
     }
 
     public static function getKey(): int

--- a/src/Response/PublishErrorResponseV1.php
+++ b/src/Response/PublishErrorResponseV1.php
@@ -11,6 +11,7 @@ use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\PublishingError;
 
 /** @phpstan-consistent-constructor */
@@ -53,14 +54,18 @@ class PublishErrorResponseV1 implements KeyVersionInterface, FromStreamBufferInt
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $errorsData = TypeCast::toArray($data['errors'] ?? []);
         $errors = array_map(
-            fn(array $e): \CrazyGoat\RabbitStream\VO\PublishingError => new PublishingError(
-                $e['publishingId'],
-                $e['code']
-            ),
-            $data['errors']
+            function (mixed $e): PublishingError {
+                $ea = is_array($e) ? $e : [];
+                return new PublishingError(
+                    TypeCast::toInt($ea['publishingId'] ?? 0),
+                    TypeCast::toInt($ea['code'] ?? 0)
+                );
+            },
+            $errorsData
         );
-        return new static($data['publisherId'], ...$errors);
+        return new static(TypeCast::toInt($data['publisherId']), ...$errors);
     }
 
     public static function getKey(): int

--- a/src/Response/QueryOffsetResponseV1.php
+++ b/src/Response/QueryOffsetResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class QueryOffsetResponseV1 implements
@@ -49,8 +50,8 @@ class QueryOffsetResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
-        $object->offset = $data['offset'];
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
+        $object->offset = TypeCast::toInt($data['offset']);
         return $object;
     }
 

--- a/src/Response/QueryPublisherSequenceResponseV1.php
+++ b/src/Response/QueryPublisherSequenceResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class QueryPublisherSequenceResponseV1 implements
@@ -49,8 +50,8 @@ class QueryPublisherSequenceResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
-        $object->sequence = $data['sequence'];
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
+        $object->sequence = TypeCast::toInt($data['sequence']);
         return $object;
     }
 

--- a/src/Response/ResolveOffsetSpecResponseV1.php
+++ b/src/Response/ResolveOffsetSpecResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class ResolveOffsetSpecResponseV1 implements
@@ -50,8 +51,8 @@ class ResolveOffsetSpecResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
-        $object->offset = $data['offset'];
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
+        $object->offset = TypeCast::toInt($data['offset']);
         return $object;
     }
 

--- a/src/Response/RouteResponseV1.php
+++ b/src/Response/RouteResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class RouteResponseV1 implements
@@ -59,8 +60,8 @@ class RouteResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        $object = new static($data['streams']);
-        $object->withCorrelationId($data['correlationId']);
+        $object = new static(TypeCast::toStringArray($data['streams'] ?? []));
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/SaslAuthenticateResponseV1.php
+++ b/src/Response/SaslAuthenticateResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class SaslAuthenticateResponseV1 implements
@@ -43,7 +44,7 @@ class SaslAuthenticateResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/SaslHandshakeResponseV1.php
+++ b/src/Response/SaslHandshakeResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class SaslHandshakeResponseV1 implements
@@ -33,8 +34,13 @@ class SaslHandshakeResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        $object = new static($data['mechanisms']);
-        $object->withCorrelationId($data['correlationId']);
+        $rawMechanisms = is_array($data['mechanisms'] ?? null) ? $data['mechanisms'] : [];
+        $mechanisms = array_map(
+            fn(mixed $m): ?string => $m === null ? null : TypeCast::toString($m),
+            array_values($rawMechanisms)
+        );
+        $object = new static($mechanisms);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/StreamStatsResponseV1.php
+++ b/src/Response/StreamStatsResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 use CrazyGoat\RabbitStream\VO\Statistic;
 
 /** @phpstan-consistent-constructor */
@@ -64,12 +65,16 @@ class StreamStatsResponseV1 implements
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
+        $statsData = TypeCast::toArray($data['stats'] ?? []);
         $stats = array_map(
-            fn(array $s): \CrazyGoat\RabbitStream\VO\Statistic => new Statistic($s['key'], $s['value']),
-            $data['stats']
+            function (mixed $s): Statistic {
+                $sa = is_array($s) ? $s : [];
+                return new Statistic(TypeCast::toString($sa['key'] ?? ''), TypeCast::toInt($sa['value'] ?? 0));
+            },
+            $statsData
         );
         $object = new static($stats);
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/SubscribeResponseV1.php
+++ b/src/Response/SubscribeResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class SubscribeResponseV1 implements
@@ -39,7 +40,7 @@ class SubscribeResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Response/TuneResponseV1.php
+++ b/src/Response/TuneResponseV1.php
@@ -9,6 +9,7 @@ use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
 use CrazyGoat\RabbitStream\Contract\KeyVersionInterface;
 use CrazyGoat\RabbitStream\Enum\KeyEnum;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, FromArrayInterface
@@ -30,7 +31,7 @@ class TuneResponseV1 implements KeyVersionInterface, ToStreamBufferInterface, Fr
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['frameMax'], $data['heartbeat']);
+        return new static(TypeCast::toInt($data['frameMax']), TypeCast::toInt($data['heartbeat']));
     }
 
     public function toStreamBuffer(): WriteBuffer

--- a/src/Response/UnsubscribeResponseV1.php
+++ b/src/Response/UnsubscribeResponseV1.php
@@ -13,6 +13,7 @@ use CrazyGoat\RabbitStream\Enum\KeyEnum;
 use CrazyGoat\RabbitStream\Trait\CommandTrait;
 use CrazyGoat\RabbitStream\Trait\CorrelationTrait;
 use CrazyGoat\RabbitStream\Trait\V1Trait;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class UnsubscribeResponseV1 implements
@@ -39,7 +40,7 @@ class UnsubscribeResponseV1 implements
     public static function fromArray(array $data): static
     {
         $object = new static();
-        $object->withCorrelationId($data['correlationId']);
+        $object->withCorrelationId(TypeCast::toInt($data['correlationId']));
         return $object;
     }
 

--- a/src/Util/TypeCast.php
+++ b/src/Util/TypeCast.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Util;
+
+/**
+ * Type-safe extraction helpers for values from mixed arrays.
+ *
+ * These methods properly narrow `mixed` values before casting,
+ * satisfying PHPStan level 9 requirements.
+ */
+final class TypeCast
+{
+    public static function toInt(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_float($value) || is_string($value) || is_bool($value)) {
+            return (int) $value;
+        }
+        return 0;
+    }
+
+    public static function toFloat(mixed $value): float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_string($value) || is_bool($value)) {
+            return (float) $value;
+        }
+        return 0.0;
+    }
+
+    public static function toString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value) || is_bool($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+
+    public static function toNullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        return self::toString($value);
+    }
+
+    public static function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return (bool) $value;
+        }
+        return false;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public static function toIntArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $result = [];
+        foreach ($value as $item) {
+            $result[] = self::toInt($item);
+        }
+        return $result;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function toStringArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $result = [];
+        foreach ($value as $item) {
+            $result[] = self::toString($item);
+        }
+        return $result;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public static function toArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values($value);
+        }
+        return [];
+    }
+}

--- a/src/VO/Broker.php
+++ b/src/VO/Broker.php
@@ -8,6 +8,7 @@ use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
@@ -56,6 +57,10 @@ class Broker implements FromStreamBufferInterface, ToArrayInterface, FromArrayIn
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['reference'], $data['host'], $data['port']);
+        return new static(
+            TypeCast::toInt($data['reference']),
+            TypeCast::toString($data['host']),
+            TypeCast::toInt($data['port'])
+        );
     }
 }

--- a/src/VO/CommandVersion.php
+++ b/src/VO/CommandVersion.php
@@ -10,6 +10,7 @@ use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
@@ -66,6 +67,10 @@ class CommandVersion implements FromStreamBufferInterface, ToStreamBufferInterfa
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['key'], $data['minVersion'], $data['maxVersion']);
+        return new static(
+            TypeCast::toInt($data['key']),
+            TypeCast::toInt($data['minVersion']),
+            TypeCast::toInt($data['maxVersion'])
+        );
     }
 }

--- a/src/VO/KeyValue.php
+++ b/src/VO/KeyValue.php
@@ -10,6 +10,7 @@ use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
@@ -49,6 +50,6 @@ class KeyValue implements FromStreamBufferInterface, ToStreamBufferInterface, To
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['key'], $data['value']);
+        return new static(TypeCast::toString($data['key']), TypeCast::toNullableString($data['value'] ?? null));
     }
 }

--- a/src/VO/PublishingError.php
+++ b/src/VO/PublishingError.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\RabbitStream\VO;
 use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class PublishingError implements ToArrayInterface, FromArrayInterface
@@ -41,6 +42,6 @@ class PublishingError implements ToArrayInterface, FromArrayInterface
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['publishingId'], $data['code']);
+        return new static(TypeCast::toInt($data['publishingId']), TypeCast::toInt($data['code']));
     }
 }

--- a/src/VO/Statistic.php
+++ b/src/VO/Statistic.php
@@ -10,6 +10,7 @@ use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\ToStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\WriteBuffer;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, ToArrayInterface, FromArrayInterface
@@ -49,6 +50,6 @@ class Statistic implements FromStreamBufferInterface, ToStreamBufferInterface, T
     /** @param array<string, mixed> $data */
     public static function fromArray(array $data): static
     {
-        return new static($data['key'], $data['value']);
+        return new static(TypeCast::toString($data['key']), TypeCast::toInt($data['value']));
     }
 }

--- a/src/VO/StreamMetadata.php
+++ b/src/VO/StreamMetadata.php
@@ -8,6 +8,7 @@ use CrazyGoat\RabbitStream\Buffer\FromArrayInterface;
 use CrazyGoat\RabbitStream\Buffer\FromStreamBufferInterface;
 use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
 use CrazyGoat\RabbitStream\Buffer\ToArrayInterface;
+use CrazyGoat\RabbitStream\Util\TypeCast;
 
 /** @phpstan-consistent-constructor */
 class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, FromArrayInterface
@@ -72,10 +73,10 @@ class StreamMetadata implements FromStreamBufferInterface, ToArrayInterface, Fro
     public static function fromArray(array $data): static
     {
         return new static(
-            $data['stream'],
-            $data['responseCode'],
-            $data['leaderReference'],
-            $data['replicasReferences']
+            TypeCast::toString($data['stream']),
+            TypeCast::toInt($data['responseCode']),
+            TypeCast::toInt($data['leaderReference']),
+            TypeCast::toIntArray($data['replicasReferences'] ?? [])
         );
     }
 }

--- a/tests/Client/AmqpDecoderMessageTest.php
+++ b/tests/Client/AmqpDecoderMessageTest.php
@@ -208,8 +208,9 @@ class AmqpDecoderMessageTest extends TestCase
         $sections = AmqpDecoder::decodeMessage($message);
 
         $this->assertSame('{"key":"value"}', $sections['body']);
-        $this->assertSame('msg-123', $sections['properties']['message-id']);
-        $this->assertSame('application/json', $sections['properties']['content-type']);
+        $properties = is_array($sections['properties']) ? $sections['properties'] : [];
+        $this->assertSame('msg-123', $properties['message-id']);
+        $this->assertSame('application/json', $properties['content-type']);
     }
 
     public function testDecodeMessageWithApplicationProperties(): void
@@ -226,8 +227,9 @@ class AmqpDecoderMessageTest extends TestCase
         $sections = AmqpDecoder::decodeMessage($message);
 
         $this->assertSame('Body content', $sections['body']);
-        $this->assertSame('custom-value', $sections['applicationProperties']['x-custom-header']);
-        $this->assertSame(5, $sections['applicationProperties']['priority']);
+        $appProps = is_array($sections['applicationProperties']) ? $sections['applicationProperties'] : [];
+        $this->assertSame('custom-value', $appProps['x-custom-header']);
+        $this->assertSame(5, $appProps['priority']);
     }
 
     public function testDecodeFullMessage(): void
@@ -251,11 +253,13 @@ class AmqpDecoderMessageTest extends TestCase
         $sections = AmqpDecoder::decodeMessage($message);
 
         $this->assertSame('Full message body', $sections['body']);
-        $this->assertSame('msg-456', $sections['properties']['message-id']);
-        $this->assertSame('Test Subject', $sections['properties']['subject']);
-        $this->assertSame('text/plain', $sections['properties']['content-type']);
-        $this->assertSame('test-suite', $sections['applicationProperties']['source']);
-        $this->assertSame(1, $sections['applicationProperties']['version']);
+        $properties = is_array($sections['properties']) ? $sections['properties'] : [];
+        $this->assertSame('msg-456', $properties['message-id']);
+        $this->assertSame('Test Subject', $properties['subject']);
+        $this->assertSame('text/plain', $properties['content-type']);
+        $appProps = is_array($sections['applicationProperties']) ? $sections['applicationProperties'] : [];
+        $this->assertSame('test-suite', $appProps['source']);
+        $this->assertSame(1, $appProps['version']);
     }
 
     public function testDecodeMessageWithAmqpValueBody(): void
@@ -291,7 +295,8 @@ class AmqpDecoderMessageTest extends TestCase
         $sections = AmqpDecoder::decodeMessage($message);
 
         $this->assertSame('Annotated message', $sections['body']);
-        $this->assertSame(12345, $sections['messageAnnotations']['x-opt-sequence-number']);
+        $annotations = is_array($sections['messageAnnotations']) ? $sections['messageAnnotations'] : [];
+        $this->assertSame(12345, $annotations['x-opt-sequence-number']);
     }
 
     public function testDecodeMessageWithMultipleDataSections(): void
@@ -330,19 +335,20 @@ class AmqpDecoderMessageTest extends TestCase
 
         $sections = AmqpDecoder::decodeMessage($message);
 
-        $this->assertSame('msg-id', $sections['properties']['message-id']);
-        $this->assertSame('user123', $sections['properties']['user-id']);
-        $this->assertSame('destination', $sections['properties']['to']);
-        $this->assertSame('test-subject', $sections['properties']['subject']);
-        $this->assertSame('reply-dest', $sections['properties']['reply-to']);
-        $this->assertSame('corr-123', $sections['properties']['correlation-id']);
-        $this->assertSame('application/json', $sections['properties']['content-type']);
-        $this->assertSame('gzip', $sections['properties']['content-encoding']);
-        $this->assertSame(1234567890, $sections['properties']['absolute-expiry-time']);
-        $this->assertSame(1234567000, $sections['properties']['creation-time']);
-        $this->assertSame('group-1', $sections['properties']['group-id']);
-        $this->assertSame(1, $sections['properties']['group-sequence']);
-        $this->assertSame('reply-group', $sections['properties']['reply-to-group-id']);
+        $properties = is_array($sections['properties']) ? $sections['properties'] : [];
+        $this->assertSame('msg-id', $properties['message-id']);
+        $this->assertSame('user123', $properties['user-id']);
+        $this->assertSame('destination', $properties['to']);
+        $this->assertSame('test-subject', $properties['subject']);
+        $this->assertSame('reply-dest', $properties['reply-to']);
+        $this->assertSame('corr-123', $properties['correlation-id']);
+        $this->assertSame('application/json', $properties['content-type']);
+        $this->assertSame('gzip', $properties['content-encoding']);
+        $this->assertSame(1234567890, $properties['absolute-expiry-time']);
+        $this->assertSame(1234567000, $properties['creation-time']);
+        $this->assertSame('group-1', $properties['group-id']);
+        $this->assertSame(1, $properties['group-sequence']);
+        $this->assertSame('reply-group', $properties['reply-to-group-id']);
     }
 
     public function testDecodeEmptyMessage(): void

--- a/tests/Client/ConsumerTest.php
+++ b/tests/Client/ConsumerTest.php
@@ -286,6 +286,7 @@ class ConsumerTest extends TestCase
         $this->assertSame($msg1, $result);
 
         $remaining = $bufferProp->getValue($consumer);
+        $this->assertIsArray($remaining);
         $this->assertCount(1, $remaining);
         $this->assertSame($msg2, $remaining[0]);
     }

--- a/tests/Client/OsirisChunkParserTest.php
+++ b/tests/Client/OsirisChunkParserTest.php
@@ -178,13 +178,13 @@ class OsirisChunkParserTest extends TestCase
 
         foreach ($entries as $entry) {
             if ($entry['type'] === 'simple') {
-                $data = $entry['data'];
-                $size = strlen((string) $data);
+                $entryData = is_scalar($entry['data']) ? (string) $entry['data'] : '';
+                $size = strlen($entryData);
                 $dataSection .= pack('N', $size);
-                $dataSection .= $data;
+                $dataSection .= $entryData;
             } elseif ($entry['type'] === 'subbatch') {
-                $codec = $entry['codec'];
-                $innerEntries = $entry['entries'];
+                $codec = is_scalar($entry['codec']) ? (int) $entry['codec'] : 0;
+                $innerEntries = is_array($entry['entries']) ? $entry['entries'] : [];
                 $count = count($innerEntries);
 
                 $header = 0x80000000 | ($codec << 25) | $count;
@@ -192,8 +192,11 @@ class OsirisChunkParserTest extends TestCase
 
                 $innerData = '';
                 foreach ($innerEntries as $innerEntry) {
-                    $innerData .= pack('N', strlen((string) $innerEntry['data']));
-                    $innerData .= $innerEntry['data'];
+                    $innerEntryArr = is_array($innerEntry) ? $innerEntry : [];
+                    $rawData = $innerEntryArr['data'] ?? '';
+                    $innerEntryData = is_scalar($rawData) ? (string) $rawData : '';
+                    $innerData .= pack('N', strlen($innerEntryData));
+                    $innerData .= $innerEntryData;
                 }
 
                 $uncompressedSize = strlen($innerData);

--- a/tests/Client/ProducerTest.php
+++ b/tests/Client/ProducerTest.php
@@ -174,7 +174,9 @@ class ProducerTest extends TestCase
         $this->assertNotNull($capturedRequest, 'PublishRequestV1 should have been captured');
         $this->assertInstanceOf(PublishRequestV1::class, $capturedRequest);
         /** @var PublishRequestV1 $capturedRequest */
-        $this->assertSame(3, count($capturedRequest->toArray()['messages']), 'Should have 3 messages');
+        $requestArray = $capturedRequest->toArray();
+        $messages = is_array($requestArray['messages']) ? $requestArray['messages'] : [];
+        $this->assertSame(3, count($messages), 'Should have 3 messages');
     }
 
     public function testWaitForConfirmsThrowsOnTimeout(): void

--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -14,8 +14,10 @@ class ProducerTest extends TestCase
 
     protected function setUp(): void
     {
-        $host = $_ENV['RABBITMQ_HOST'] ?? '127.0.0.1';
-        $port = (int) ($_ENV['RABBITMQ_PORT'] ?? 5552);
+        $hostVal = $_ENV['RABBITMQ_HOST'] ?? '127.0.0.1';
+        $host = is_scalar($hostVal) ? (string) $hostVal : '127.0.0.1';
+        $portVal = $_ENV['RABBITMQ_PORT'] ?? 5552;
+        $port = is_scalar($portVal) ? (int) $portVal : 5552;
 
         $this->connection = Connection::create($host, $port);
         $this->streamName = 'test-producer-' . uniqid();


### PR DESCRIPTION
## Summary

- Bumps PHPStan analysis level from 8 to **9 (maximum)** — the strictest level
- Created `src/Util/TypeCast.php` utility class for safe type narrowing from `mixed` values
- Added `unpackInt()`/`unpackFloat()` helpers to `AmqpDecoder` for safe unpacking
- Fixed all `fromArray()` methods across VO and Response classes with proper type casting
- Updated all Response classes, VO classes, and test files to satisfy level 9 strictness
- Updated CI job name to `PHPStan (level 9)`

**45 files changed, 384 insertions, 144 deletions**

Closes #83