### PR TITLE
chore: add php>=8.1 constraint and document QA commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,18 @@ The `run-e2e.sh` script starts RabbitMQ via `docker compose`, waits for it to be
 
 ---
 
+## QA Commands
+
+```bash
+composer phpstan     # static analysis (PHPStan)
+composer cs          # check code style (PHPCS PSR-12)
+composer cs-fix      # auto-fix code style (phpcbf)
+composer rector      # preview refactoring suggestions (dry-run)
+composer rector:fix  # apply Rector refactoring
+```
+
+---
+
 ## Directory Structure
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         }
     },
     "require": {
+        "php": ">=8.1",
         "psr/log": "^3.0"
     },
     "require-dev": {
@@ -32,6 +33,8 @@
         "lint": ["phpcs --standard=phpcs.xml.dist", "@rector", "@phpstan"],
         "lint:fix": ["@rector:fix", "phpcbf --standard=phpcs.xml.dist"],
         "phpstan": "phpstan analyse",
+        "cs": "phpcs --standard=phpcs.xml.dist",
+        "cs-fix": "phpcbf --standard=phpcs.xml.dist",
         "test": "phpunit",
         "test:unit": "phpunit --testsuite unit",
         "test:e2e": "phpunit --testsuite e2e",


### PR DESCRIPTION
Closes #84

## Changes
- Added `"php": ">=8.1"` to `composer.json` require section
- Added `composer cs` and `composer cs-fix` script aliases
- Added `## QA Commands` section to `AGENTS.md` documenting all QA tool shortcuts

## Verification
- `composer validate` passes
- `composer phpstan` — no errors
- `composer cs` — no violations
- Unit tests: 306 passing