### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-03-20
+
 ### Changed
 - **PHPStan level 9 (max)** — bumped static analysis from level 0 to level 9 incrementally:
   - Created `src/Util/TypeCast.php` utility class for safe type narrowing from `mixed`
@@ -15,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Fixed all `mixed` type strictness violations with proper type casting (level 9)
 
 ### Added
+- **High-Level Client API** — `Connection`, `Producer`, `Consumer`, `Message` classes providing a simple, user-friendly API on top of the low-level protocol implementation
 - **PHP_CodeSniffer with PSR-12 and Slevomat Coding Standard** — comprehensive code style enforcement:
   - Added `phpcsstandards/php_codesniffer` ^3.9 and `slevomat/coding-standard` ^8.15 to dev dependencies
   - Created `phpcs.xml.dist` with strict rules (PSR-12 + Slevomat)


### PR DESCRIPTION
## Summary

- Prepare CHANGELOG.md for v1.0.0 release — move `[Unreleased]` to `[1.0.0] - 2026-03-20`
- Add "High-Level Client API" entry summarizing the major feature of this release
- All 306 unit tests pass, lint/rector/PHPStan level 9 clean

## What's in v1.0.0

This is the first major release of `crazy-goat/rabbit-stream`. Key highlights:

- **High-Level Client API** — `Connection`, `Producer`, `Consumer`, `Message` classes
- **Full RabbitMQ Streams Protocol** — all 26+ commands implemented
- **AMQP 1.0 message decoding** — `AmqpDecoder`, `AmqpMessageDecoder`, `OsirisChunkParser`
- **Swappable serialization** — `BinarySerializerInterface` + `PhpBinarySerializer`
- **Code quality** — PSR-12, PHPStan level 9, Rector
- **Breaking changes** from pre-1.0: removed deprecated `StreamClient`, `StreamClientConfig`, `ProducerConfig`; fixed `ReadBuffer::gatString()` typo; moved interfaces to `Contract\` namespace

Closes #70