### PR TITLE
fix: prevent correlationId desync on heartbeat echo

### DIFF
--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -319,7 +319,9 @@ class StreamConnection
         switch ($key) {
             case KeyEnum::HEARTBEAT->value:
                 HeartbeatRequestV1::fromStreamBuffer($frame);
-                $this->sendMessage(new HeartbeatRequestV1());
+                $heartbeat = new HeartbeatRequestV1();
+                $content = $this->serializer->serialize($heartbeat);
+                $this->sendFrame((new WriteBuffer())->addUInt32(strlen($content))->addRaw($content)->getContents());
                 if ($this->heartbeatCallback instanceof \Closure) {
                     ($this->heartbeatCallback)();
                 }


### PR DESCRIPTION
## Problem

In `dispatchServerPush()`, heartbeat echo was sent via `sendMessage()` which increments `$this->correlationId`. Heartbeat frames have no correlation ID, so this increment was spurious.

Every heartbeat received caused the correlation counter to increment, leading to **correlation ID mismatches** between requests and responses over time.

## Solution

Use `sendFrame()` directly (like `ConsumerUpdateReply` does), bypassing `sendMessage()` and avoiding the spurious correlationId increment.

## Changes

- `src/StreamConnection.php`: Changed heartbeat echo from `sendMessage()` to `sendFrame()` with manual frame construction

## Testing

- All 313 unit tests pass
- This fix prevents correlation ID drift in long-running connections with heartbeats

Fixes #101