### PR TITLE
fix: log warning when readLoop() drops unexpected frames

### DIFF
--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -66,9 +66,10 @@ class StreamConnection
 
         $result = socket_connect($socket, $this->host, $this->port);
         if (!$result) {
+            $error = socket_strerror(socket_last_error($socket));
+            socket_close($socket);
             throw new \RuntimeException(
-                "Cannot connect to {$this->host}:{$this->port}: " .
-                socket_strerror(socket_last_error($this->socket))
+                "Cannot connect to {$this->host}:{$this->port}: " . $error
             );
         }
 
@@ -301,6 +302,11 @@ class StreamConnection
                 if (!$this->connected) {
                     break;
                 }
+            } else {
+                $this->logger->warning(
+                    'readLoop() received unexpected non-server-push frame, discarding',
+                    ['key' => sprintf('0x%04x', $key)]
+                );
             }
 
             if ($maxFrames !== null && $dispatched >= $maxFrames) {


### PR DESCRIPTION
## Summary

- Fixes #104
- **Bug fix:** `connect()` used `$this->socket` in error path before assignment, causing a secondary error that masked the real connection failure. Now captures error from local `$socket`, closes the leaked socket, then throws.
- `readLoop()` now logs a `warning` via PSR logger when it receives a non-server-push frame instead of silently discarding it
- Frame key is included in the log context (`0x00xx` format) for easier debugging