### PR TITLE
feat: Consumer backpressure to prevent unbounded buffer growth (closes #107)

### DIFF
--- a/src/Client/Consumer.php
+++ b/src/Client/Consumer.php
@@ -15,6 +15,8 @@ use CrazyGoat\RabbitStream\VO\OffsetSpec;
 
 class Consumer
 {
+    private const MAX_UINT16 = 65535;
+
     /** @var Message[] */
     private array $buffer = [];
     private int $messagesProcessed = 0;
@@ -50,7 +52,7 @@ class Consumer
                     $this->connection->sendMessage(
                         new CreditRequestV1($this->subscriptionId, 1)
                     );
-                } elseif ($this->pendingCredits < 65535) {
+                } elseif ($this->pendingCredits < self::MAX_UINT16) {
                     $this->pendingCredits++;
                 }
             },
@@ -171,7 +173,7 @@ class Consumer
             return;
         }
 
-        $creditsToSend = min($this->pendingCredits, $availableSlots, 65535);
+        $creditsToSend = min($this->pendingCredits, $availableSlots, self::MAX_UINT16);
         $this->connection->sendMessage(
             new CreditRequestV1($this->subscriptionId, $creditsToSend)
         );

--- a/tests/Client/ConsumerTest.php
+++ b/tests/Client/ConsumerTest.php
@@ -40,11 +40,11 @@ class ConsumerTest extends TestCase
         $params = $reflection->getParameters();
 
         $this->assertCount(1, $params);
-        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertSame('timeout', $params[0]->getName());
         $type = $params[0]->getType();
         $this->assertInstanceOf(\ReflectionNamedType::class, $type);
-        $this->assertEquals('float', $type->getName());
-        $this->assertEquals(5.0, $params[0]->getDefaultValue());
+        $this->assertSame('float', $type->getName());
+        $this->assertSame(5.0, $params[0]->getDefaultValue());
 
         // Test calling with float timeout works
         $result = $consumer->read(timeout: 0.5);
@@ -66,11 +66,11 @@ class ConsumerTest extends TestCase
         $params = $reflection->getParameters();
 
         $this->assertCount(1, $params);
-        $this->assertEquals('timeout', $params[0]->getName());
+        $this->assertSame('timeout', $params[0]->getName());
         $type = $params[0]->getType();
         $this->assertInstanceOf(\ReflectionNamedType::class, $type);
-        $this->assertEquals('float', $type->getName());
-        $this->assertEquals(5.0, $params[0]->getDefaultValue());
+        $this->assertSame('float', $type->getName());
+        $this->assertSame(5.0, $params[0]->getDefaultValue());
 
         // Test calling with float timeout works
         $result = $consumer->readOne(timeout: 0.5);


### PR DESCRIPTION
## Summary

Closes #107

Implements backpressure mechanism in Consumer to prevent unbounded internal message buffer growth that could lead to memory exhaustion.

## Changes

- Added `maxBufferSize` parameter to Consumer constructor (default: 1000)
- Added `pendingCredits` property to track deferred credits when buffer is full
- Modified subscriber callback to withhold credits when buffer reaches `maxBufferSize`
- Added `sendPendingCredits()` method that sends credits proportional to available buffer space
- Modified `read()` and `readOne()` to send pending credits after draining messages
- Added validation that `maxBufferSize` must be greater than 0
- Capped `pendingCredits` at 65535 (max uint16 per protocol spec)

## Backpressure Behavior

- When buffer has room: credit is granted immediately (1 per chunk)
- When buffer is full: credit is deferred to `pendingCredits`
- When `read()` drains the buffer: all pending credits are sent in a single batched request
- When `readOne()` frees space: credits are sent proportional to available slots

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client
- [x] Java client: rabbitmq/rabbitmq-stream-java-client
- [x] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec — no message encoding changes

## Testing

- Unit tests: pass (338 tests, 731 assertions)
- Lint (PHPCS): pass
- PHPStan: pass
- New tests added:
  - `testMaxBufferSizeMustBeGreaterThanZero` — validates constructor parameter
  - `testCreditWithheldWhenBufferExceedsMaxBufferSize` — verifies backpressure logic
  - `testPendingCreditsSentAfterReadDrainsBuffer` — verifies credit batching on read()
  - `testPendingCreditsSentAfterReadOneDrainsBuffer` — verifies credit sending on readOne()