### PR TITLE
fix: mask password in SaslAuthenticateRequestV1 to prevent credential leakage (closes #112)

### DIFF
--- a/src/Request/SaslAuthenticateRequestV1.php
+++ b/src/Request/SaslAuthenticateRequestV1.php
@@ -27,9 +27,10 @@ class SaslAuthenticateRequestV1 implements
     public function __construct(private string $mechanism, private string $username, private string $password)
     {
     }
+
     public function toStreamBuffer(): WriteBuffer
     {
-        return  self::getKeYVersion($this->getCorrelationId())
+        return self::getKeYVersion($this->getCorrelationId())
             ->addString($this->mechanism)
             ->addBytes("\0" . $this->username . "\0" . $this->password);
     }
@@ -40,8 +41,14 @@ class SaslAuthenticateRequestV1 implements
         return [
             'mechanism' => $this->mechanism,
             'username' => $this->username,
-            'password' => $this->password,
+            'password' => '***',
         ];
+    }
+
+    /** @return array<string, string> */
+    public function __debugInfo(): array
+    {
+        return $this->toArray();
     }
 
     public static function getKey(): int

--- a/tests/Request/SaslAuthenticateRequestV1Test.php
+++ b/tests/Request/SaslAuthenticateRequestV1Test.php
@@ -26,4 +26,33 @@ class SaslAuthenticateRequestV1Test extends TestCase
 
         $this->assertSame($expected, $bytes);
     }
+
+    public function testPasswordIsMaskedInToArray(): void
+    {
+        $request = new SaslAuthenticateRequestV1('PLAIN', 'guest', 'secretpassword123');
+        $array = $request->toArray();
+
+        $this->assertSame('***', $array['password']);
+        $this->assertSame('guest', $array['username']);
+        $this->assertSame('PLAIN', $array['mechanism']);
+    }
+
+    public function testPasswordIsMaskedInDebugInfo(): void
+    {
+        $request = new SaslAuthenticateRequestV1('PLAIN', 'guest', 'secretpassword123');
+        $debugInfo = $request->__debugInfo();
+
+        $this->assertSame('***', $debugInfo['password']);
+        $this->assertSame('guest', $debugInfo['username']);
+        $this->assertSame('PLAIN', $debugInfo['mechanism']);
+    }
+
+    public function testPasswordIsNotMaskedInStreamBuffer(): void
+    {
+        $request = new SaslAuthenticateRequestV1('PLAIN', 'guest', 'secretpassword123');
+        $bytes = $request->toStreamBuffer()->getContents();
+
+        $this->assertStringContainsString('secretpassword123', $bytes);
+        $this->assertStringContainsString('guest', $bytes);
+    }
 }

--- a/tests/Request/ToArrayTest.php
+++ b/tests/Request/ToArrayTest.php
@@ -101,7 +101,7 @@ class ToArrayTest extends TestCase
         $this->assertSame([
             'mechanism' => 'PLAIN',
             'username' => 'user',
-            'password' => 'pass',
+            'password' => '***',
         ], $request->toArray());
     }
 


### PR DESCRIPTION
## Summary

Closes #112

Security fix: Passwords are now masked in SaslAuthenticateRequestV1::toArray() output to prevent credential leakage when the array is logged, serialized, or dumped for debugging.

## Changes

- Mask password as '***' in toArray() output
- Added __debugInfo() method to protect var_dump()/print_r() output  
- Added comprehensive tests for password masking
- Wire protocol (toStreamBuffer) unchanged - real password still sent to server

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client
- [x] Java client: rabbitmq/rabbitmq-stream-java-client
- [x] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec — not applicable, this is a SASL authentication frame

## Testing

- Unit tests: 337 pass
- Lint (PHPCS): pass
- PHPStan: pass
- Rector: pass