### PR TITLE
fix: add response type validation for PeerProperties, SaslAuthenticate, and Open (closes #106)

### DIFF
--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -21,7 +21,10 @@ use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\CreateResponseV1;
 use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
 use CrazyGoat\RabbitStream\Response\QueryOffsetResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\Response\StreamStatsResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
@@ -59,7 +62,10 @@ class Connection
 
         // 1. PeerProperties
         $streamConnection->sendMessage(new PeerPropertiesToStreamBufferV1());
-        $streamConnection->readMessage();
+        $peerResponse = $streamConnection->readMessage();
+        if (!$peerResponse instanceof PeerPropertiesResponseV1) {
+            throw new \Exception("Expected PeerPropertiesResponseV1, got " . $peerResponse::class);
+        }
 
         // 2. SaslHandshake
         $streamConnection->sendMessage(new SaslHandshakeRequestV1());
@@ -75,7 +81,10 @@ class Connection
 
         // 3. SaslAuthenticate
         $streamConnection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', $user, $password));
-        $streamConnection->readMessage();
+        $authResponse = $streamConnection->readMessage();
+        if (!$authResponse instanceof SaslAuthenticateResponseV1) {
+            throw new \Exception("Expected SaslAuthenticateResponseV1, got " . $authResponse::class);
+        }
 
         // 4. Tune (server sends TuneRequestV1)
         $tune = $streamConnection->readMessage();
@@ -88,7 +97,10 @@ class Connection
 
         // 6. Open
         $streamConnection->sendMessage(new OpenRequest($vhost));
-        $streamConnection->readMessage();
+        $openResponse = $streamConnection->readMessage();
+        if (!$openResponse instanceof OpenResponseV1) {
+            throw new \Exception("Expected OpenResponseV1, got " . $openResponse::class);
+        }
 
         return new self($streamConnection);
     }


### PR DESCRIPTION
## Summary

Closes #106

## Changes

- Added  validation for  in Connection::create() (step 1)
- Added  validation for  in Connection::create() (step 3)
- Added  validation for  in Connection::create() (step 6)
- Added missing imports for , , and 

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client
- [x] Java client: rabbitmq/rabbitmq-stream-java-client
- [x] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec — this change only touches stream protocol handshake validation

## Testing

- Unit tests: pass (337 tests, 729 assertions)
- Lint (PHPCS): pass
- PHPStan: pass

## Notes

This follows the existing validation pattern already used for SaslHandshake (step 2) and Tune (step 4) responses. Previously, if the server returned an error response or unexpected frame type during these handshake steps, the code would silently continue with undefined behavior. Now it throws a clear exception with the actual received type.