### PR TITLE
refactor: fix getKeyVersion typo (closes #110)

### DIFF
--- a/src/Request/SaslAuthenticateRequestV1.php
+++ b/src/Request/SaslAuthenticateRequestV1.php
@@ -30,7 +30,7 @@ class SaslAuthenticateRequestV1 implements
 
     public function toStreamBuffer(): WriteBuffer
     {
-        return self::getKeYVersion($this->getCorrelationId())
+        return self::getKeyVersion($this->getCorrelationId())
             ->addString($this->mechanism)
             ->addBytes("\0" . $this->username . "\0" . $this->password);
     }

--- a/src/Request/TuneRequestV1.php
+++ b/src/Request/TuneRequestV1.php
@@ -31,7 +31,7 @@ class TuneRequestV1 implements FromStreamBufferInterface, ToStreamBufferInterfac
 
     public function toStreamBuffer(): WriteBuffer
     {
-        return self::getKeYVersion()
+        return self::getKeyVersion()
             ->addUInt32($this->frameMax)
             ->addUInt32($this->heartbeat);
     }


### PR DESCRIPTION
## Summary

Closes #110

## Changes

- Fixed method name typo `getKeYVersion` → `getKeyVersion` in `SaslAuthenticateRequestV1.php`
- Fixed method name typo `getKeYVersion` → `getKeyVersion` in `TuneRequestV1.php`

## Reference implementations checked

- [N/A] Go client: rabbitmq/rabbitmq-stream-go-client — not applicable for code style fix
- [N/A] Java client: rabbitmq/rabbitmq-stream-java-client — not applicable for code style fix
- [N/A] Protocol spec: PROTOCOL.adoc — not applicable for code style fix
- [N/A] AMQP 1.0 spec — not applicable

## Testing

- Unit tests: pass (337 tests, 729 assertions)
- Lint (PHPCS): pass
- PHPStan: pass