### PR TITLE
fix: change StreamConnection default host from 172.17.0.2 to 127.0.0.1

### DIFF
--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -50,7 +50,7 @@ class StreamConnection
     private int $maxFrameSize = self::DEFAULT_MAX_FRAME_SIZE;
 
     public function __construct(
-        private readonly string $host = '172.17.0.2',
+        private readonly string $host = '127.0.0.1',
         private readonly int $port = 5552,
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly BinarySerializerInterface $serializer = new PhpBinarySerializer(),


### PR DESCRIPTION
## Summary

Fixes #111

`StreamConnection` constructor defaulted to `'172.17.0.2'` (a Docker bridge network IP), while `Connection::create()` correctly defaults to `'127.0.0.1'`. This caused unexpected behavior when users instantiated `StreamConnection` directly.

## Changes

- Changed default `$host` parameter from `'172.17.0.2'` to `'127.0.0.1'` in `StreamConnection::__construct()`

## Testing

- All 337 unit tests pass
- PHPCS, PHPStan, and Rector all pass
- No breaking changes (users already passing explicit hosts are unaffected)