### PR TITLE
test: fix testPublishMultipleMessages timeout by using waitForConfirms (closes #137)

### DIFF
--- a/tests/E2E/PublishTest.php
+++ b/tests/E2E/PublishTest.php
@@ -45,7 +45,7 @@ class PublishTest extends TestCase
         );
 
         $producer->send('hello world');
-        $connection->readLoop(maxFrames: 1);
+        $producer->waitForConfirms(timeout: 5.0);
 
         $this->assertSame([0], $confirmedIds);
 
@@ -71,9 +71,9 @@ class PublishTest extends TestCase
         $producer->send('message-two');
         $producer->send('message-three');
 
-        $connection->readLoop(maxFrames: 3);
+        $producer->waitForConfirms(timeout: 5.0);
 
-        $this->assertCount(3, $confirmedIds);
+        $this->assertSame([0, 1, 2], $confirmedIds);
 
         $producer->close();
         $connection->close();


### PR DESCRIPTION
## Summary

Closes #137

## Changes

- Changed `testPublishMultipleMessages` to use `$producer->waitForConfirms(timeout: 5.0)` instead of `$connection->readLoop(maxFrames: 3)`
- Changed `testPublishSingleMessage` to use `$producer->waitForConfirms(timeout: 5.0)` instead of `$connection->readLoop(maxFrames: 1)` for consistency
- Changed assertion from `assertCount(3, $confirmedIds)` to `assertSame([0, 1, 2], $confirmedIds)` for consistency with `testPublishSingleMessage`

## Problem

The original test used `readLoop(maxFrames: 3)` expecting 3 separate server-push frames. However, RabbitMQ batches all 3 publish confirms into a single `PublishConfirm` frame. This caused `readLoop` to hang for 30 seconds waiting for 2 more frames that never arrived.

## Solution

Using `Producer::waitForConfirms()` is the correct approach because:
1. It tracks the actual number of pending confirms (not raw frames)
2. It loops calling `readLoop()` until all confirms are received or timeout expires
3. It properly handles batched confirms from RabbitMQ

## Testing

- Unit tests: pass
- Lint (PHPCS): pass
- PHPStan: pass
- E2E tests: pass (testPublishMultipleMessages now completes in <1s instead of 30s)