### PR TITLE
test: reduce excessive timeouts in ConsumerTest E2E tests (closes #138)

### DIFF
--- a/tests/E2E/ConsumerTest.php
+++ b/tests/E2E/ConsumerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
 use PHPUnit\Framework\TestCase;
 
@@ -13,13 +14,13 @@ class ConsumerTest extends TestCase
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
 
+    private ?Connection $connection = null;
+    private string $streamName;
+
     private function amqp(string $body): string
     {
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
-
-    private ?Connection $connection = null;
-    private string $streamName;
 
     public static function setUpBeforeClass(): void
     {
@@ -42,7 +43,7 @@ class ConsumerTest extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->connection instanceof \CrazyGoat\RabbitStream\Client\Connection) {
+        if ($this->connection instanceof Connection) {
             try {
                 $this->connection->deleteStream($this->streamName);
             } catch (\Exception) {
@@ -74,9 +75,9 @@ class ConsumerTest extends TestCase
         $consumer = $this->connection->createConsumer($this->streamName, OffsetSpec::first());
 
         $received = [];
-        $deadline = time() + 10;
+        $deadline = time() + 5;
         while (count($received) < 3 && time() < $deadline) {
-            $messages = $consumer->read(timeout: 2);
+            $messages = $consumer->read(timeout: 0.5);
             foreach ($messages as $msg) {
                 $received[] = $msg->getBody();
             }
@@ -101,9 +102,9 @@ class ConsumerTest extends TestCase
         $consumer = $this->connection->createConsumer($this->streamName, OffsetSpec::first());
 
         $msg = null;
-        $deadline = time() + 10;
-        while (!$msg instanceof \CrazyGoat\RabbitStream\Client\Message && time() < $deadline) {
-            $msg = $consumer->readOne(timeout: 2);
+        $deadline = time() + 5;
+        while (!$msg instanceof Message && time() < $deadline) {
+            $msg = $consumer->readOne(timeout: 0.5);
         }
 
         $consumer->close();
@@ -128,9 +129,9 @@ class ConsumerTest extends TestCase
         );
 
         $messages = [];
-        $deadline = time() + 10;
+        $deadline = time() + 5;
         while ($messages === [] && time() < $deadline) {
-            $messages = $consumer->read(timeout: 2);
+            $messages = $consumer->read(timeout: 0.5);
         }
 
         $this->assertNotEmpty($messages);

--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -4,29 +4,34 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
+use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
 use PHPUnit\Framework\TestCase;
 
 class ProducerTest extends TestCase
 {
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
     private ?Connection $connection = null;
     private string $streamName;
 
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
     protected function setUp(): void
     {
-        $hostVal = $_ENV['RABBITMQ_HOST'] ?? '127.0.0.1';
-        $host = is_scalar($hostVal) ? (string) $hostVal : '127.0.0.1';
-        $portVal = $_ENV['RABBITMQ_PORT'] ?? 5552;
-        $port = is_scalar($portVal) ? (int) $portVal : 5552;
-
-        $this->connection = Connection::create($host, $port);
+        $this->connection = Connection::create(self::$host, self::$port);
         $this->streamName = 'test-producer-' . uniqid();
         $this->connection->createStream($this->streamName);
     }
 
     protected function tearDown(): void
     {
-        if ($this->connection instanceof \CrazyGoat\RabbitStream\Client\Connection) {
+        if ($this->connection instanceof Connection) {
             try {
                 $this->connection->deleteStream($this->streamName);
             } catch (\Exception) {
@@ -42,7 +47,7 @@ class ProducerTest extends TestCase
         $confirmed = [];
         $producer = $this->connection->createProducer(
             $this->streamName,
-            onConfirm: function ($status) use (&$confirmed): void {
+            onConfirm: function (ConfirmationStatus $status) use (&$confirmed): void {
                 $confirmed[] = $status;
             }
         );
@@ -62,7 +67,7 @@ class ProducerTest extends TestCase
         $confirmed = [];
         $producer = $this->connection->createProducer(
             $this->streamName,
-            onConfirm: function ($status) use (&$confirmed): void {
+            onConfirm: function (ConfirmationStatus $status) use (&$confirmed): void {
                 $confirmed[] = $status;
             }
         );


### PR DESCRIPTION
## Summary

Closes #138

Reduces excessive timeout values in ConsumerTest E2E deadline loops to save ~2-3 seconds per test run. Also includes improvements to ProducerTest for consistency with other E2E tests.

## Changes

### ConsumerTest.php
- Reduced `read()` timeout from 2s to 0.5s in polling loops (3 tests)
- Reduced deadline from 10s to 5s in polling loops (3 tests)
- Changed `testReadReturnsEmptyOnTimeout` timeout from 1s to 0.5s → reverted to 1s for CI safety
- Added proper `use` import for `Message` class instead of FQCN inline
- Fixed FQCN usage for `Connection` class in `tearDown()`
- Reordered properties to follow PSR-12 (properties before methods)

### ProducerTest.php
- Refactored to use `setUpBeforeClass()` + static properties pattern (consistent with ConsumerTest)
- Changed from `$_ENV` to `getenv()` for environment variable access
- Added proper `use` import for `Connection` class instead of FQCN inline
- Added `ConfirmationStatus` type hint to callback parameters

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client
- [x] Java client: rabbitmq/rabbitmq-stream-java-client
- [x] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec — no message encoding changes

## Testing

- Unit tests: pass (347 tests, 767 assertions)
- Lint (PHPCS): pass
- PHPStan: pass
- E2E tests: pass (61 tests, 304 assertions)