### PR TITLE
fix: replace mb_convert_encoding with mb_check_encoding for UTF-8 validation (closes #117)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": ">=8.1",
+        "ext-mbstring": "*",
         "psr/log": "^3.0"
     },
     "require-dev": {

--- a/src/Buffer/WriteBuffer.php
+++ b/src/Buffer/WriteBuffer.php
@@ -113,14 +113,13 @@ class WriteBuffer
         if ($value === null) {
             $this->buffer .= pack('n', 0xFFFF); // -1 as unsigned int16
         } else {
-            $utf8Value = mb_convert_encoding($value, 'UTF-8', 'auto');
-            if ($utf8Value === false) {
-                throw new \RuntimeException('Failed to convert string to UTF-8');
+            if (!mb_check_encoding($value, 'UTF-8')) {
+                throw new \InvalidArgumentException('String must be valid UTF-8');
             }
-            $length = strlen($utf8Value);
+            $length = strlen($value);
             $this->validateInt($length, 0, self::INT16_MAX, 'string length');
             $this->buffer .= pack('n', $length);
-            $this->buffer .= $utf8Value;
+            $this->buffer .= $value;
         }
         return $this;
     }

--- a/tests/Buffer/WriteBufferTest.php
+++ b/tests/Buffer/WriteBufferTest.php
@@ -57,6 +57,58 @@ class WriteBufferTest extends TestCase
         $this->assertSame("\x00\x02hi", $buf->getContents());
     }
 
+    public function testAddStringWithUtf8(): void
+    {
+        $buf = (new WriteBuffer())->addString('héllo');
+        $this->assertSame("\x00\x06héllo", $buf->getContents());
+    }
+
+    public function testAddStringWithMultiByteCharacters(): void
+    {
+        $buf = (new WriteBuffer())->addString('日本語');
+        $this->assertSame("\x00\x09日本語", $buf->getContents());
+    }
+
+    public function testAddStringWithEmoji(): void
+    {
+        $buf = (new WriteBuffer())->addString('Hello 👋 World 🌍');
+        $this->assertSame("\x00\x15Hello 👋 World 🌍", $buf->getContents());
+    }
+
+    public function testAddEmptyString(): void
+    {
+        $buf = (new WriteBuffer())->addString('');
+        $this->assertSame("\x00\x00", $buf->getContents());
+    }
+
+    public function testAddInvalidUtf8StringThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('String must be valid UTF-8');
+
+        $invalidUtf8 = "\x80\x81";
+        (new WriteBuffer())->addString($invalidUtf8);
+    }
+
+    public function testAddStringAtMaxLength(): void
+    {
+        $maxLengthString = str_repeat('a', 32767);
+        $buf = (new WriteBuffer())->addString($maxLengthString);
+        $contents = $buf->getContents();
+
+        $this->assertSame("\x7F\xFF", substr($contents, 0, 2));
+        $this->assertSame($maxLengthString, substr($contents, 2));
+    }
+
+    public function testAddStringExceedingMaxLengthThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('out of range for string length');
+
+        $tooLongString = str_repeat('a', 32768);
+        (new WriteBuffer())->addString($tooLongString);
+    }
+
     public function testAddNullString(): void
     {
         $buf = (new WriteBuffer())->addString(null);


### PR DESCRIPTION
## Summary

Closes #117

Replaces unreliable `mb_convert_encoding($value, 'UTF-8', 'auto')` with strict UTF-8 validation using `mb_check_encoding()`. The 'auto' encoding detection is heuristic-based and can silently corrupt data by misidentifying encodings.

## Changes

- `src/Buffer/WriteBuffer.php`: Replace auto-conversion with UTF-8 validation, throw `InvalidArgumentException` for invalid input
- `tests/Buffer/WriteBufferTest.php`: Add comprehensive tests for UTF-8 validation, multi-byte characters (2/3/4 byte), emoji, empty strings, and boundary length tests (32767/32768 bytes)
- `composer.json`: Add `ext-mbstring` requirement

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client - uses `utf8.ValidString()` for validation in AMQP codec
- [x] Java client: rabbitmq/rabbitmq-stream-java-client - uses `StandardCharsets.UTF_8` explicitly
- [x] Protocol spec: PROTOCOL.adoc - strings defined as "int16 length + UTF8-encoded content"
- [N/A] AMQP 1.0 spec - this change affects stream protocol framing, not message encoding

## Testing

- Unit tests: pass (354 tests, 777 assertions)
- Lint (PHPCS): pass
- PHPStan: pass
- E2E tests: pass (61 tests, 304 assertions)