### PR TITLE
E2E test: Connection resilience — operations after socket error

### DIFF
--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -262,6 +262,11 @@ class Connection implements ConnectionInterface
         }
     }
 
+    public function isConnected(): bool
+    {
+        return $this->streamConnection->isConnected();
+    }
+
     public function __destruct()
     {
         if (!$this->closed) {

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -118,7 +118,7 @@ class StreamConnection
                 $this->connected = false;
                 return false;
             }
-        } catch (\Error $e) {
+        } catch (\Error) {
             // Socket is invalid/closed
             $this->connected = false;
             return false;
@@ -243,7 +243,7 @@ class StreamConnection
             $written = socket_write($this->socket, $frame, strlen($frame));
         } catch (\Error $e) {
             $this->connected = false;
-            throw new ConnectionException("Failed to write to socket: " . $e->getMessage());
+            throw new ConnectionException("Failed to write to socket: " . $e->getMessage(), $e->getCode(), $e);
         }
 
         if ($written === false) {

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -101,7 +101,30 @@ class StreamConnection
 
     public function isConnected(): bool
     {
-        return $this->connected;
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (!$this->socket instanceof \Socket) {
+            return false;
+        }
+
+        // Check if socket is still valid by attempting to get its error status
+        // A closed socket will fail this operation
+        try {
+            $error = @socket_last_error($this->socket);
+            if ($error !== 0) {
+                // Socket has an error, mark as disconnected
+                $this->connected = false;
+                return false;
+            }
+        } catch (\Error $e) {
+            // Socket is invalid/closed
+            $this->connected = false;
+            return false;
+        }
+
+        return true;
     }
 
     public function setMaxFrameSize(int $maxFrameSize): void
@@ -216,7 +239,13 @@ class StreamConnection
             throw new ConnectionException("Cannot write: socket is not connected");
         }
 
-        $written = socket_write($this->socket, $frame, strlen($frame));
+        try {
+            $written = socket_write($this->socket, $frame, strlen($frame));
+        } catch (\Error $e) {
+            $this->connected = false;
+            throw new ConnectionException("Failed to write to socket: " . $e->getMessage());
+        }
+
         if ($written === false) {
             throw new ConnectionException(
                 "Failed to write to socket: " . socket_strerror(socket_last_error($this->socket))

--- a/tests/E2E/ConnectionResilienceTest.php
+++ b/tests/E2E/ConnectionResilienceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Exception\ConnectionException;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group destructive
+ * @group slow
+ */
+class ConnectionResilienceTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    public function testOperationAfterSocketDisconnect(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-resilience-' . uniqid();
+        $connection->createStream($streamName);
+
+        // Simulate socket error by closing socket via reflection
+        $this->forceCloseSocket($connection);
+
+        // Next operation should throw ConnectionException
+        $this->expectException(ConnectionException::class);
+        $connection->createStream('another-stream-' . uniqid());
+    }
+
+    public function testIsConnectedReturnsFalseAfterSocketError(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $this->assertTrue($connection->isConnected());
+
+        // Simulate socket error
+        $this->forceCloseSocket($connection);
+
+        // isConnected() should return false
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testNoResourceLeaksAfterSocketError(): void
+    {
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-resilience-leak-' . uniqid();
+        $connection->createStream($streamName);
+
+        // Force socket close
+        $this->forceCloseSocket($connection);
+
+        // Destructor should not throw or cause warnings
+        unset($connection);
+
+        // If we reach here without errors, test passes
+        $this->addToAssertionCount(1);
+    }
+
+    private function forceCloseSocket(Connection $connection): void
+    {
+        // Access StreamConnection from Connection
+        $streamConnReflection = new \ReflectionProperty(Connection::class, 'streamConnection');
+        $streamConnection = $streamConnReflection->getValue($connection);
+
+        $this->assertInstanceOf(StreamConnection::class, $streamConnection);
+
+        // Access socket from StreamConnection
+        $socketReflection = new \ReflectionProperty(StreamConnection::class, 'socket');
+        $socket = $socketReflection->getValue($streamConnection);
+
+        if ($socket !== null) {
+            // Force close the socket
+            @socket_close($socket);
+        }
+    }
+}

--- a/tests/E2E/ConnectionResilienceTest.php
+++ b/tests/E2E/ConnectionResilienceTest.php
@@ -99,7 +99,7 @@ class ConnectionResilienceTest extends TestCase
         $socketReflection = new \ReflectionProperty(StreamConnection::class, 'socket');
         $socket = $socketReflection->getValue($streamConnection);
 
-        if ($socket !== null) {
+        if ($socket instanceof \Socket) {
             // Force close the socket
             @socket_close($socket);
         }


### PR DESCRIPTION
Closes #170

## Problem

No E2E test verifies client behavior when the **underlying TCP socket encounters an error** mid-session. In production, network partitions, server restarts, and load balancer timeouts cause socket errors.

## Expected tests

```php
public function testOperationAfterSocketDisconnect(): void
{
    $connection = Connection::create(...);
    $streamName = 'test-resilience-' . uniqid();
    $connection->createStream($streamName);

    // Simulate socket error by stopping Docker container
    // or closing the socket via reflection

    $this->expectException(\RuntimeException::class);
    $connection->createStream('another-stream');
}

public function testIsConnectedReturnsFalseAfterSocketError(): void
{
    // After socket error, isConnected() should return false
}
```

## Why it matters

- Network failures are inevitable in production
- The client must fail fast with clear errors, not hang or corrupt state
- `readBytes()` returns `null` on `SOCKET_ETIMEDOUT` but throws on other errors — both paths need testing

## Notes

- This test may require Docker manipulation (stop/start container)
- Alternative: use reflection to close the socket directly
- Consider marking as `@group slow` or `@group destructive`

## Acceptance criteria

- [ ] Socket error → clear `RuntimeException` on next operation
- [ ] `isConnected()` returns `false` after socket error
- [ ] No resource leaks after socket error