### PR TITLE
E2E test: Virtual host access control — invalid vhost rejection

### DIFF
--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -123,18 +123,28 @@ class ConnectionHandshakeTest extends TestCase
         $this->assertFalse($connection->isConnected());
     }
 
-    public function testInvalidCredentialsThrows(): void
+    public function testInvalidVhostThrows(): void
     {
         $this->connection = $this->createConnection();
 
+        // Complete handshake up to Tune
         $this->connection->sendMessage(new PeerPropertiesRequestV1());
         $this->connection->readMessage();
 
         $this->connection->sendMessage(new SaslHandshakeRequestV1());
         $this->connection->readMessage();
 
+        $this->connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $this->connection->readMessage();
+
+        $tune = $this->connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+
+        $this->connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        // Now attempt to open a non-existent vhost
         $this->expectException(\Exception::class);
-        $this->connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'wrong', 'credentials'));
+        $this->connection->sendMessage(new OpenRequestV1('/nonexistent-vhost'));
         $this->connection->readMessage(timeout: 2.0);
     }
 }


### PR DESCRIPTION
Closes #149

## Problem

No E2E test verifies that the server rejects connections to a non-existent or unauthorized virtual host. The `OpenRequest` always uses `'/'` in all tests. The `ResponseCodeEnum::VIRTUAL_HOST_ACCESS_FAILURE` (0x0c) code path is never exercised.

## Expected test

```php
public function testInvalidVhostThrows(): void
{
    $connection = $this->createConnection();
    // ... complete handshake up to Tune ...

    $this->expectException(\Exception::class);
    $connection->sendMessage(new OpenRequest('/nonexistent-vhost'));
    $connection->readMessage();
}
```

## Why it matters

- Security: validates vhost isolation is enforced at the protocol level
- Ensures the client correctly handles `VIRTUAL_HOST_ACCESS_FAILURE` responses
- Important for multi-tenant deployments

## Acceptance criteria

- [ ] Test with non-existent vhost → exception with `VIRTUAL_HOST_ACCESS_FAILURE`
- [ ] Connection should be unusable after vhost rejection