### PR TITLE
E2E test: SASL mechanism validation — unsupported mechanism rejection

### DIFF
--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -137,4 +137,36 @@ class ConnectionHandshakeTest extends TestCase
         $this->connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'wrong', 'credentials'));
         $this->connection->readMessage(timeout: 2.0);
     }
+
+    public function testUnsupportedSaslMechanismThrows(): void
+    {
+        $this->connection = $this->createConnection();
+
+        $this->connection->sendMessage(new PeerPropertiesRequestV1());
+        $this->connection->readMessage();
+
+        $this->connection->sendMessage(new SaslHandshakeRequestV1());
+        $this->connection->readMessage();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SASL_MECHANISM_NOT_SUPPORTED');
+        $this->connection->sendMessage(new SaslAuthenticateRequestV1('SCRAM-SHA-256', 'guest', 'guest'));
+        $this->connection->readMessage(timeout: 2.0);
+    }
+
+    public function testEmptySaslMechanismThrows(): void
+    {
+        $this->connection = $this->createConnection();
+
+        $this->connection->sendMessage(new PeerPropertiesRequestV1());
+        $this->connection->readMessage();
+
+        $this->connection->sendMessage(new SaslHandshakeRequestV1());
+        $this->connection->readMessage();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SASL_MECHANISM_NOT_SUPPORTED');
+        $this->connection->sendMessage(new SaslAuthenticateRequestV1('', 'guest', 'guest'));
+        $this->connection->readMessage(timeout: 2.0);
+    }
 }


### PR DESCRIPTION
Closes #148

## Problem

No E2E test verifies that the server correctly rejects an unsupported SASL mechanism. The `ConnectionHandshakeTest` only tests `PLAIN` authentication. If a client sends a mechanism name the server doesn't support (e.g. `"SCRAM-SHA-256"`, `"EXTERNAL"`, or an empty string `""`), the server should respond with `SASL_MECHANISM_NOT_SUPPORTED` (0x07).

## Expected test

```php
public function testUnsupportedSaslMechanismThrows(): void
{
    $connection = $this->createConnection();
    $connection->sendMessage(new PeerPropertiesToStreamBufferV1());
    $connection->readMessage();
    $connection->sendMessage(new SaslHandshakeRequestV1());
    $connection->readMessage();

    $this->expectException(\Exception::class);
    $connection->sendMessage(new SaslAuthenticateRequestV1('SCRAM-SHA-256', 'guest', 'guest'));
    $connection->readMessage(timeout: 2.0);
}
```

## Why it matters

- Validates that the client library correctly propagates SASL errors
- Ensures `ResponseCodeEnum::SASL_MECHANISM_NOT_SUPPORTED` path is exercised
- Security: confirms the server enforces mechanism restrictions

## Acceptance criteria

- [ ] Test with a non-existent SASL mechanism name → exception thrown
- [ ] Test with empty string mechanism → exception thrown
- [ ] Verify the exception message contains meaningful error info