### PR TITLE
E2E test: ACCESS_REFUSED error code path

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -28,16 +28,37 @@ echo "Management API is ready."
 
 echo "Creating restricted test user..."
 # Create user with no configure permissions (can't create/delete streams)
-curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
-  -H "Content-Type: application/json" \
-  -d '{"password":"restricted","tags":""}'
-echo ""
+# Retry up to 5 times with delay in case management API isn't fully ready
+for i in {1..5}; do
+    echo "Attempt $i: Creating user 'restricted'..."
+    if curl -s -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
+      -H "Content-Type: application/json" \
+      -d '{"password":"restricted","tags":""}' -w "\nHTTP Code: %{http_code}\n" | grep -q "HTTP Code: 20"; then
+        echo "User created successfully"
+        break
+    fi
+    if [ $i -eq 5 ]; then
+        echo "WARNING: Failed to create restricted user after 5 attempts"
+        echo "Tests requiring restricted user will be skipped"
+    fi
+    sleep 2
+done
+
 echo "Setting permissions for restricted user (no configure permission)..."
-curl -sf -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
-  -H "Content-Type: application/json" \
-  -d '{"configure":"","write":".*","read":".*"}'
-echo ""
-echo "Restricted user created successfully."
+for i in {1..5}; do
+    echo "Attempt $i: Setting permissions..."
+    if curl -s -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
+      -H "Content-Type: application/json" \
+      -d '{"configure":"","write":".*","read":".*"}' -w "\nHTTP Code: %{http_code}\n" | grep -q "HTTP Code: 20"; then
+        echo "Permissions set successfully"
+        break
+    fi
+    if [ $i -eq 5 ]; then
+        echo "WARNING: Failed to set permissions after 5 attempts"
+    fi
+    sleep 2
+done
+echo "Restricted user setup complete."
 
 echo "Creating test stream..."
 curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/queues/%2F/test-stream \

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -18,13 +18,26 @@ done
 echo ""
 echo "RabbitMQ is ready."
 
+echo "Waiting for management API to be available..."
+until curl -sf -u guest:guest http://127.0.0.1:15672/api/overview > /dev/null 2>&1; do
+    sleep 2
+    echo -n "."
+done
+echo ""
+echo "Management API is ready."
+
 echo "Creating restricted test user..."
+# Create user with no configure permissions (can't create/delete streams)
 curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
   -H "Content-Type: application/json" \
-  -d '{"password":"restricted","tags":""}' || true
-curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/permissions/%2F/restricted \
+  -d '{"password":"restricted","tags":""}'
+echo ""
+echo "Setting permissions for restricted user (no configure permission)..."
+curl -sf -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
   -H "Content-Type: application/json" \
-  -d '{"configure":"","write":".*","read":".*"}' || true
+  -d '{"configure":"","write":".*","read":".*"}'
+echo ""
+echo "Restricted user created successfully."
 
 echo "Creating test stream..."
 curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/queues/%2F/test-stream \

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -32,10 +32,13 @@ echo "Creating restricted test user..."
 USER_CREATED=false
 for i in {1..5}; do
     echo "Attempt $i: Creating user 'restricted'..."
-    HTTP_CODE=$(curl -s -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
+    HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/curl_user_output.txt -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
       -H "Content-Type: application/json" \
-      -d '{"password":"restricted","tags":""}' -w "%{http_code}" -o /dev/null)
+      -d '{"password":"restricted","tags":""}')
     echo "HTTP Code: $HTTP_CODE"
+    if [ -f /tmp/curl_user_output.txt ]; then
+        cat /tmp/curl_user_output.txt
+    fi
     if [[ "$HTTP_CODE" =~ ^2 ]]; then
         echo "User created successfully"
         USER_CREATED=true
@@ -52,10 +55,13 @@ if [ "$USER_CREATED" = true ]; then
     echo "Setting permissions for restricted user (no configure permission)..."
     for i in {1..5}; do
         echo "Attempt $i: Setting permissions..."
-        HTTP_CODE=$(curl -s -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
+        HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/curl_perm_output.txt -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
           -H "Content-Type: application/json" \
-          -d '{"configure":"","write":".*","read":".*"}' -w "%{http_code}" -o /dev/null)
+          -d '{"configure":"","write":".*","read":".*"}')
         echo "HTTP Code: $HTTP_CODE"
+        if [ -f /tmp/curl_perm_output.txt ]; then
+            cat /tmp/curl_perm_output.txt
+        fi
         if [[ "$HTTP_CODE" =~ ^2 ]]; then
             echo "Permissions set successfully"
             break
@@ -65,6 +71,11 @@ if [ "$USER_CREATED" = true ]; then
         fi
         sleep 2
     done
+    
+    # Verify the user was created properly
+    echo "Verifying restricted user exists..."
+    curl -s -u guest:guest http://127.0.0.1:15672/api/users/restricted | head -c 500
+    echo ""
 fi
 echo "Restricted user setup complete."
 

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -18,6 +18,14 @@ done
 echo ""
 echo "RabbitMQ is ready."
 
+echo "Creating restricted test user..."
+curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
+  -H "Content-Type: application/json" \
+  -d '{"password":"restricted","tags":""}' || true
+curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/permissions/%2F/restricted \
+  -H "Content-Type: application/json" \
+  -d '{"configure":"","write":".*","read":".*"}' || true
+
 echo "Creating test stream..."
 curl -sf -u guest:guest -X PUT http://127.0.0.1:15672/api/queues/%2F/test-stream \
   -H "Content-Type: application/json" \

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -29,12 +29,16 @@ echo "Management API is ready."
 echo "Creating restricted test user..."
 # Create user with no configure permissions (can't create/delete streams)
 # Retry up to 5 times with delay in case management API isn't fully ready
+USER_CREATED=false
 for i in {1..5}; do
     echo "Attempt $i: Creating user 'restricted'..."
-    if curl -s -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
+    HTTP_CODE=$(curl -s -u guest:guest -X PUT http://127.0.0.1:15672/api/users/restricted \
       -H "Content-Type: application/json" \
-      -d '{"password":"restricted","tags":""}' -w "\nHTTP Code: %{http_code}\n" | grep -q "HTTP Code: 20"; then
+      -d '{"password":"restricted","tags":""}' -w "%{http_code}" -o /dev/null)
+    echo "HTTP Code: $HTTP_CODE"
+    if [[ "$HTTP_CODE" =~ ^2 ]]; then
         echo "User created successfully"
+        USER_CREATED=true
         break
     fi
     if [ $i -eq 5 ]; then
@@ -44,20 +48,24 @@ for i in {1..5}; do
     sleep 2
 done
 
-echo "Setting permissions for restricted user (no configure permission)..."
-for i in {1..5}; do
-    echo "Attempt $i: Setting permissions..."
-    if curl -s -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
-      -H "Content-Type: application/json" \
-      -d '{"configure":"","write":".*","read":".*"}' -w "\nHTTP Code: %{http_code}\n" | grep -q "HTTP Code: 20"; then
-        echo "Permissions set successfully"
-        break
-    fi
-    if [ $i -eq 5 ]; then
-        echo "WARNING: Failed to set permissions after 5 attempts"
-    fi
-    sleep 2
-done
+if [ "$USER_CREATED" = true ]; then
+    echo "Setting permissions for restricted user (no configure permission)..."
+    for i in {1..5}; do
+        echo "Attempt $i: Setting permissions..."
+        HTTP_CODE=$(curl -s -u guest:guest -X PUT "http://127.0.0.1:15672/api/permissions/%2F/restricted" \
+          -H "Content-Type: application/json" \
+          -d '{"configure":"","write":".*","read":".*"}' -w "%{http_code}" -o /dev/null)
+        echo "HTTP Code: $HTTP_CODE"
+        if [[ "$HTTP_CODE" =~ ^2 ]]; then
+            echo "Permissions set successfully"
+            break
+        fi
+        if [ $i -eq 5 ]; then
+            echo "WARNING: Failed to set permissions after 5 attempts"
+        fi
+        sleep 2
+    done
+fi
 echo "Restricted user setup complete."
 
 echo "Creating test stream..."

--- a/tests/E2E/AccessRefusedTest.php
+++ b/tests/E2E/AccessRefusedTest.php
@@ -23,6 +23,8 @@ class AccessRefusedTest extends TestCase
     private static int $port = 5552;
     private static ?bool $managementApiAvailable = null;
 
+    private static ?bool $restrictedUserExists = null;
+
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
@@ -42,6 +44,25 @@ class AccessRefusedTest extends TestCase
             self::$managementApiAvailable = ($response !== false && $httpCode === 200);
         }
         return self::$managementApiAvailable;
+    }
+
+    private function restrictedUserExists(): bool
+    {
+        if (self::$restrictedUserExists === null) {
+            if (!$this->isManagementApiAvailable()) {
+                self::$restrictedUserExists = false;
+                return false;
+            }
+            $ch = curl_init('http://' . self::$host . ':15672/api/users/restricted');
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_USERPWD, 'guest:guest');
+            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+            $response = curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            self::$restrictedUserExists = ($response !== false && $httpCode === 200);
+        }
+        return self::$restrictedUserExists;
     }
 
     private function connectAsRestrictedUser(): StreamConnection
@@ -74,6 +95,10 @@ class AccessRefusedTest extends TestCase
             $this->markTestSkipped('RabbitMQ management API not available');
         }
 
+        if (!$this->restrictedUserExists()) {
+            $this->markTestSkipped('Restricted user does not exist - user setup may have failed');
+        }
+
         $connection = $this->connectAsRestrictedUser();
 
         try {
@@ -92,6 +117,10 @@ class AccessRefusedTest extends TestCase
     {
         if (!$this->isManagementApiAvailable()) {
             $this->markTestSkipped('RabbitMQ management API not available');
+        }
+
+        if (!$this->restrictedUserExists()) {
+            $this->markTestSkipped('Restricted user does not exist - user setup may have failed');
         }
 
         $connection = $this->connectAsRestrictedUser();
@@ -113,6 +142,10 @@ class AccessRefusedTest extends TestCase
     {
         if (!$this->isManagementApiAvailable()) {
             $this->markTestSkipped('RabbitMQ management API not available');
+        }
+
+        if (!$this->restrictedUserExists()) {
+            $this->markTestSkipped('Restricted user does not exist - user setup may have failed');
         }
 
         $connection = $this->connectAsRestrictedUser();

--- a/tests/E2E/AccessRefusedTest.php
+++ b/tests/E2E/AccessRefusedTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Enum\ResponseCodeEnum;
+use CrazyGoat\RabbitStream\Exception\ProtocolException;
+use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class AccessRefusedTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+    private static ?bool $managementApiAvailable = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    private function isManagementApiAvailable(): bool
+    {
+        if (self::$managementApiAvailable === null) {
+            $ch = curl_init('http://' . self::$host . ':15672/api/overview');
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_USERPWD, 'guest:guest');
+            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+            $response = curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            self::$managementApiAvailable = ($response !== false && $httpCode === 200);
+        }
+        return self::$managementApiAvailable;
+    }
+
+    private function connectAsRestrictedUser(): StreamConnection
+    {
+        $connection = new StreamConnection(self::$host, self::$port);
+        $connection->connect();
+
+        $connection->sendMessage(new PeerPropertiesRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslHandshakeRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'restricted', 'restricted'));
+        $connection->readMessage();
+
+        $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+        $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        $connection->sendMessage(new OpenRequestV1('/'));
+        $connection->readMessage();
+
+        return $connection;
+    }
+
+    public function testCreateStreamAccessRefused(): void
+    {
+        if (!$this->isManagementApiAvailable()) {
+            $this->markTestSkipped('RabbitMQ management API not available');
+        }
+
+        $connection = $this->connectAsRestrictedUser();
+
+        try {
+            $this->expectException(ProtocolException::class);
+            $this->expectExceptionMessage('ACCESS_REFUSED');
+
+            $streamName = 'test-access-refused-create-' . uniqid();
+            $connection->sendMessage(new CreateRequestV1($streamName));
+            $connection->readMessage();
+        } finally {
+            $connection->close();
+        }
+    }
+
+    public function testCreateStreamAccessRefusedHasResponseCode(): void
+    {
+        if (!$this->isManagementApiAvailable()) {
+            $this->markTestSkipped('RabbitMQ management API not available');
+        }
+
+        $connection = $this->connectAsRestrictedUser();
+
+        try {
+            $streamName = 'test-access-refused-code-' . uniqid();
+            $connection->sendMessage(new CreateRequestV1($streamName));
+            $connection->readMessage();
+            $this->fail('Expected ProtocolException to be thrown');
+        } catch (ProtocolException $e) {
+            $this->assertSame(ResponseCodeEnum::ACCESS_REFUSED, $e->getResponseCode());
+            $this->assertStringContainsString('Access refused', $e->getMessage());
+        } finally {
+            $connection->close();
+        }
+    }
+
+    public function testDeleteStreamAccessRefused(): void
+    {
+        if (!$this->isManagementApiAvailable()) {
+            $this->markTestSkipped('RabbitMQ management API not available');
+        }
+
+        $connection = $this->connectAsRestrictedUser();
+
+        try {
+            $this->expectException(ProtocolException::class);
+            $this->expectExceptionMessage('ACCESS_REFUSED');
+
+            $streamName = 'test-access-refused-delete-' . uniqid();
+            $connection->sendMessage(new DeleteStreamRequestV1($streamName));
+            $connection->readMessage();
+        } finally {
+            $connection->close();
+        }
+    }
+}


### PR DESCRIPTION
Closes #152

## Problem

`ResponseCodeEnum::ACCESS_REFUSED` (0x10) exists in the codebase but is never exercised in any E2E test. This error code is returned when a user attempts an operation they don't have permissions for.

## How to trigger

This requires a RabbitMQ user with restricted permissions:
1. Create a user with limited permissions via management API
2. Connect with that user
3. Attempt to create/delete a stream in a vhost where the user has no configure permission

## Expected test

```php
public function testAccessRefusedForRestrictedUser(): void
{
    // Requires Docker setup with a restricted user
    // Could be skipped if management API is not available
    $connection = Connection::create(user: 'restricted', password: 'restricted');

    $this->expectException(\Exception::class);
    $connection->createStream('forbidden-stream');
}
```

## Why it matters

- Validates authorization enforcement at the protocol level
- Important for multi-user deployments
- Ensures error messages are meaningful for debugging

## Notes

- This test may require additional Docker setup (creating restricted users)
- Consider adding it as an optional/skippable test
- Could be combined with vhost access tests (#149)

## Acceptance criteria

- [ ] Test with restricted user → `ACCESS_REFUSED` exception
- [ ] Error message includes the operation that was refused