### PR TITLE
E2E test: Subscribe with OffsetSpec::timestamp() — time-based offset

### DIFF
--- a/tests/E2E/SubscribeTest.php
+++ b/tests/E2E/SubscribeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
+use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
@@ -51,6 +52,11 @@ class SubscribeTest extends TestCase
         $connection->readMessage();
 
         return $connection;
+    }
+
+    private function amqp(string $body): string
+    {
+        return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
     public function testSubscribeToStream(): void
@@ -134,5 +140,123 @@ class SubscribeTest extends TestCase
         $connection->readMessage();
 
         $connection->close();
+    }
+
+    public function testSubscribeFromTimestamp(): void
+    {
+        // Use higher-level Connection API for proper async handling
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-subscribe-timestamp-' . uniqid();
+        $connection->createStream($streamName);
+
+        // Publish first batch of messages
+        $producer = $connection->createProducer($streamName);
+        $producer->sendBatch([
+            $this->amqp('message-before-1'),
+            $this->amqp('message-before-2'),
+        ]);
+        $producer->waitForConfirms(timeout: 5);
+
+        // Record timestamp after first batch
+        usleep(100000); // 100ms delay to ensure clean separation
+        $timestamp = (int)(microtime(true) * 1000);
+        usleep(100000); // Another 100ms delay
+
+        // Publish second batch of messages
+        $producer->sendBatch([
+            $this->amqp('message-after-1'),
+            $this->amqp('message-after-2'),
+            $this->amqp('message-after-3'),
+        ]);
+        $producer->waitForConfirms(timeout: 5);
+        $producer->close();
+
+        // Subscribe from the recorded timestamp
+        $consumer = $connection->createConsumer(
+            $streamName,
+            OffsetSpec::timestamp($timestamp)
+        );
+
+        // Read messages - should only get the 3 messages published after timestamp
+        $received = [];
+        $deadline = time() + 5;
+        while (count($received) < 3 && time() < $deadline) {
+            $messages = $consumer->read(timeout: 0.5);
+            foreach ($messages as $msg) {
+                $received[] = $msg->getBody();
+            }
+        }
+
+        $consumer->close();
+
+        // Cleanup
+        try {
+            $connection->deleteStream($streamName);
+        } catch (\Exception) {
+            // Ignore cleanup errors
+        }
+        $connection->close();
+
+        // Verify we got exactly the 3 messages published after the timestamp
+        $this->assertCount(3, $received, 'Should receive only messages published after timestamp');
+        $this->assertContains('message-after-1', $received);
+        $this->assertContains('message-after-2', $received);
+        $this->assertContains('message-after-3', $received);
+        $this->assertNotContains('message-before-1', $received);
+        $this->assertNotContains('message-before-2', $received);
+    }
+
+    public function testSubscribeFromFutureTimestamp(): void
+    {
+        // Use higher-level Connection API for proper async handling
+        $connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+
+        $streamName = 'test-subscribe-future-' . uniqid();
+        $connection->createStream($streamName);
+
+        // Publish messages
+        $producer = $connection->createProducer($streamName);
+        $producer->sendBatch([
+            $this->amqp('message-1'),
+            $this->amqp('message-2'),
+        ]);
+        $producer->waitForConfirms(timeout: 5);
+        $producer->close();
+
+        // Subscribe with a timestamp far in the future (1 hour from now)
+        $futureTimestamp = (int)(microtime(true) * 1000) + (3600 * 1000);
+        $consumer = $connection->createConsumer(
+            $streamName,
+            OffsetSpec::timestamp($futureTimestamp)
+        );
+
+        // Try to read messages - should timeout/get empty array
+        $messages = $consumer->read(timeout: 1);
+
+        $consumer->close();
+
+        // Cleanup
+        try {
+            $connection->deleteStream($streamName);
+        } catch (\Exception) {
+            // Ignore cleanup errors
+        }
+        $connection->close();
+
+        // Verify no messages received (future timestamp means no messages yet)
+        $this->assertSame([], $messages, 'Should receive no messages when subscribing from future timestamp');
     }
 }


### PR DESCRIPTION
Closes #155

## Problem

`OffsetSpec` supports `TYPE_TIMESTAMP` (0x0005) for time-based subscriptions, but **no E2E test exercises this path**. Time-based offset is important for replaying messages from a specific point in time.

## Expected test

```php
public function testSubscribeFromTimestamp(): void
{
    // 1. Publish messages
    // 2. Record current timestamp
    // 3. Publish more messages
    // 4. Subscribe with OffsetSpec::timestamp($recordedTimestamp)
    // 5. Verify only messages after the timestamp are received
}
```

## Why it matters

- Time-based replay is a key feature of RabbitMQ Streams
- The `OffsetSpec::timestamp()` factory method exists but is untested E2E
- Serialization of timestamp offset type differs from other types

## Acceptance criteria

- [ ] Subscribe with a past timestamp → receive messages from that point
- [ ] Subscribe with a future timestamp → receive no messages (timeout)
- [ ] Verify timestamp is correctly serialized as milliseconds since epoch