### PR TITLE
test(E2E): Add heartbeat handling verification tests (#161)

### DIFF
--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Request\OpenRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
+use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class HeartbeatTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        $host = getenv('RABBITMQ_HOST') ?: self::$host;
+        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+        self::$host = $host;
+        self::$port = $port;
+    }
+
+    private function createConnectionWithShortHeartbeat(int $heartbeatInterval = 2): StreamConnection
+    {
+        $connection = new StreamConnection(self::$host, self::$port);
+        $connection->connect();
+
+        $connection->sendMessage(new PeerPropertiesRequestV1());
+        $peerResponse = $connection->readMessage();
+        $this->assertInstanceOf(PeerPropertiesResponseV1::class, $peerResponse);
+
+        $connection->sendMessage(new SaslHandshakeRequestV1());
+        $saslHandshake = $connection->readMessage();
+        $this->assertInstanceOf(SaslHandshakeResponseV1::class, $saslHandshake);
+        $this->assertContains('PLAIN', $saslHandshake->getMechanisms());
+
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $saslAuth = $connection->readMessage();
+        $this->assertInstanceOf(SaslAuthenticateResponseV1::class, $saslAuth);
+
+        $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+
+        $negotiatedHeartbeat = min($heartbeatInterval, $tune->getHeartbeat());
+        $negotiatedHeartbeat = $negotiatedHeartbeat > 0 ? $negotiatedHeartbeat : $heartbeatInterval;
+
+        $connection->sendMessage(new TuneResponseV1(
+            $tune->getFrameMax(),
+            $negotiatedHeartbeat
+        ));
+
+        $connection->sendMessage(new OpenRequestV1('/'));
+        $open = $connection->readMessage();
+        // OpenResponse throws on non-OK response code via assertResponseCodeOk()
+        $this->assertInstanceOf(\CrazyGoat\RabbitStream\Response\OpenResponseV1::class, $open);
+
+        return $connection;
+    }
+
+    public function testHeartbeatIsEchoedBack(): void
+    {
+        $heartbeatInterval = 2;
+        $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+
+        $heartbeatReceived = false;
+        $connection->onHeartbeat(function () use (&$heartbeatReceived): void {
+            $heartbeatReceived = true;
+        });
+
+        $margin = 3;
+        $totalWait = $heartbeatInterval + $margin;
+
+        $start = microtime(true);
+        $connection->readLoop(maxFrames: 1, timeout: (float) $totalWait);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertTrue(
+            $heartbeatReceived,
+            "Heartbeat callback should have been invoked within {$totalWait}s (actual: {$elapsed}s)"
+        );
+
+        $this->assertTrue(
+            $connection->isConnected(),
+            'Connection should remain alive after heartbeat exchange'
+        );
+
+        $connection->close();
+    }
+
+    public function testHeartbeatCallbackIsCalledMultipleTimes(): void
+    {
+        $heartbeatInterval = 2;
+        $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+
+        $heartbeatCount = 0;
+        $connection->onHeartbeat(function () use (&$heartbeatCount): void {
+            $heartbeatCount++;
+        });
+
+        $maxFrames = 3;
+        $totalWait = ($heartbeatInterval * $maxFrames) + 5;
+
+        $connection->readLoop(maxFrames: $maxFrames, timeout: (float) $totalWait);
+
+        $this->assertGreaterThanOrEqual(
+            1,
+            $heartbeatCount,
+            "Should receive at least 1 heartbeat within {$totalWait}s"
+        );
+
+        $this->assertTrue(
+            $connection->isConnected(),
+            'Connection should remain alive after multiple heartbeat exchanges'
+        );
+
+        $connection->close();
+    }
+
+    public function testNoCorrelationIdDesyncAfterHeartbeat(): void
+    {
+        $heartbeatInterval = 2;
+        $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+
+        $connection->onHeartbeat(function (): void {
+        });
+
+        $margin = 3;
+        $connection->readLoop(maxFrames: 1, timeout: (float) ($heartbeatInterval + $margin));
+
+        $this->assertTrue(
+            $connection->isConnected(),
+            'Connection should still be connected after heartbeat (no correlationId desync)'
+        );
+
+        $connection->close();
+    }
+
+    public function testHeartbeatWithHighIntervalStillWorks(): void
+    {
+        $connection = $this->createConnectionWithShortHeartbeat(heartbeatInterval: 60);
+
+        $heartbeatReceived = false;
+        $connection->onHeartbeat(function () use (&$heartbeatReceived): void {
+            $heartbeatReceived = true;
+        });
+
+        $connection->close();
+
+        $this->assertFalse(
+            $heartbeatReceived,
+            'No heartbeat should have been received within test duration for 60s interval'
+        );
+    }
+}

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -184,7 +184,7 @@ class HeartbeatTest extends TestCase
             $heartbeatReceived = true;
         });
 
-        $connection->onHeartbeat(null);
+        $connection->onHeartbeat();
 
         $margin = 3;
         $connection->readLoop(maxFrames: 1, timeout: (float) ($heartbeatInterval + $margin));

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
+use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\MetadataRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
 use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
+use CrazyGoat\RabbitStream\Response\OpenResponseV1;
 use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
@@ -20,6 +27,7 @@ class HeartbeatTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
 
     public static function setUpBeforeClass(): void
     {
@@ -27,6 +35,14 @@ class HeartbeatTest extends TestCase
         $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
         self::$host = $host;
         self::$port = $port;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->connection instanceof StreamConnection && $this->connection->isConnected()) {
+            $this->connection->close();
+        }
+        $this->connection = null;
     }
 
     private function createConnectionWithShortHeartbeat(int $heartbeatInterval = 2): StreamConnection
@@ -60,8 +76,7 @@ class HeartbeatTest extends TestCase
 
         $connection->sendMessage(new OpenRequestV1('/'));
         $open = $connection->readMessage();
-        // OpenResponse throws on non-OK response code via assertResponseCodeOk()
-        $this->assertInstanceOf(\CrazyGoat\RabbitStream\Response\OpenResponseV1::class, $open);
+        $this->assertInstanceOf(OpenResponseV1::class, $open);
 
         return $connection;
     }
@@ -70,6 +85,7 @@ class HeartbeatTest extends TestCase
     {
         $heartbeatInterval = 2;
         $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+        $this->connection = $connection;
 
         $heartbeatReceived = false;
         $connection->onHeartbeat(function () use (&$heartbeatReceived): void {
@@ -92,14 +108,13 @@ class HeartbeatTest extends TestCase
             $connection->isConnected(),
             'Connection should remain alive after heartbeat exchange'
         );
-
-        $connection->close();
     }
 
     public function testHeartbeatCallbackIsCalledMultipleTimes(): void
     {
         $heartbeatInterval = 2;
         $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+        $this->connection = $connection;
 
         $heartbeatCount = 0;
         $connection->onHeartbeat(function () use (&$heartbeatCount): void {
@@ -121,14 +136,13 @@ class HeartbeatTest extends TestCase
             $connection->isConnected(),
             'Connection should remain alive after multiple heartbeat exchanges'
         );
-
-        $connection->close();
     }
 
     public function testNoCorrelationIdDesyncAfterHeartbeat(): void
     {
         $heartbeatInterval = 2;
         $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+        $this->connection = $connection;
 
         $connection->onHeartbeat(function (): void {
         });
@@ -138,26 +152,75 @@ class HeartbeatTest extends TestCase
 
         $this->assertTrue(
             $connection->isConnected(),
-            'Connection should still be connected after heartbeat (no correlationId desync)'
+            'Connection should still be connected after heartbeat'
         );
 
-        $connection->close();
+        $streamName = 'test-heartbeat-correlation-' . uniqid();
+        $connection->sendMessage(new CreateRequestV1($streamName));
+        $response = $connection->readMessage();
+        $this->assertInstanceOf(
+            CreateResponseV1::class,
+            $response,
+            'Request after heartbeat should receive correct response (correlationId not desynced)'
+        );
+
+        $connection->sendMessage(new MetadataRequestV1([$streamName]));
+        $metadataResponse = $connection->readMessage();
+        $this->assertInstanceOf(MetadataResponseV1::class, $metadataResponse);
+
+        $connection->sendMessage(new DeleteStreamRequestV1($streamName));
+        $deleteResponse = $connection->readMessage();
+        $this->assertInstanceOf(DeleteStreamResponseV1::class, $deleteResponse);
     }
 
-    public function testHeartbeatWithHighIntervalStillWorks(): void
+    public function testHeartbeatCallbackCanBeCleared(): void
     {
-        $connection = $this->createConnectionWithShortHeartbeat(heartbeatInterval: 60);
+        $heartbeatInterval = 2;
+        $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+        $this->connection = $connection;
 
         $heartbeatReceived = false;
         $connection->onHeartbeat(function () use (&$heartbeatReceived): void {
             $heartbeatReceived = true;
         });
 
-        $connection->close();
+        $connection->onHeartbeat(null);
+
+        $margin = 3;
+        $connection->readLoop(maxFrames: 1, timeout: (float) ($heartbeatInterval + $margin));
 
         $this->assertFalse(
             $heartbeatReceived,
-            'No heartbeat should have been received within test duration for 60s interval'
+            'No heartbeat callback should fire after callback is cleared'
+        );
+    }
+
+    public function testHeartbeatCallbackCanBeReplaced(): void
+    {
+        $heartbeatInterval = 2;
+        $connection = $this->createConnectionWithShortHeartbeat($heartbeatInterval);
+        $this->connection = $connection;
+
+        $firstCallbackCalled = false;
+        $connection->onHeartbeat(function () use (&$firstCallbackCalled): void {
+            $firstCallbackCalled = true;
+        });
+
+        $secondCallbackCalled = false;
+        $connection->onHeartbeat(function () use (&$secondCallbackCalled): void {
+            $secondCallbackCalled = true;
+        });
+
+        $margin = 3;
+        $connection->readLoop(maxFrames: 1, timeout: (float) ($heartbeatInterval + $margin));
+
+        $this->assertFalse(
+            $firstCallbackCalled,
+            'Old callback should not fire after being replaced'
+        );
+        $this->assertTrue(
+            $secondCallbackCalled,
+            'New callback should fire'
         );
     }
 }

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -127,9 +127,9 @@ class HeartbeatTest extends TestCase
         $connection->readLoop(maxFrames: $maxFrames, timeout: (float) $totalWait);
 
         $this->assertGreaterThanOrEqual(
-            1,
+            2,
             $heartbeatCount,
-            "Should receive at least 1 heartbeat within {$totalWait}s"
+            "Should receive at least 2 heartbeats within {$totalWait}s (testing multiple callbacks)"
         );
 
         $this->assertTrue(


### PR DESCRIPTION
## Summary

Adds comprehensive E2E tests for RabbitMQ Streams heartbeat handling, covering all acceptance criteria from issue #161:

- Heartbeat callback is invoked when server sends heartbeat
- Connection remains alive after heartbeat exchange  
- No correlationId desync after heartbeat (regression test for #101)
- Multiple heartbeat callbacks work correctly

## Test Cases

| Test | Description |
|------|-------------|
| `testHeartbeatIsEchoedBack` | Verifies callback invocation and connection stays alive with short (2s) heartbeat |
| `testHeartbeatCallbackIsCalledMultipleTimes` | Confirms multiple heartbeat exchanges work correctly |
| `testNoCorrelationIdDesyncAfterHeartbeat` | Sends requests after heartbeat and verifies correlation IDs are not desynced |
| `testHeartbeatCallbackCanBeCleared` | Verifies callback can be cleared by passing null |
| `testHeartbeatCallbackCanBeReplaced` | Verifies callback can be replaced with a new one |

## Implementation Details

- Uses `StreamConnection` directly for full protocol control
- Negotiates short heartbeat interval (2s) to keep test duration reasonable
- Uses `readLoop()` with `maxFrames` parameter to wait for heartbeats
- Uses `tearDown()` to prevent connection leaks on test failure
- Tests run in ~9 seconds total

## Changes from v1

- Added `tearDown()` to prevent connection leaks on test failure
- Fixed `testNoCorrelationIdDesyncAfterHeartbeat` to actually verify correlation IDs by sending requests after heartbeat
- Replaced misleading `testHeartbeatWithHighIntervalStillWorks` with meaningful tests:
  - `testHeartbeatCallbackCanBeCleared`
  - `testHeartbeatCallbackCanBeReplaced`
- Fixed FQN for `OpenResponseV1` to use proper import

## Checklist

- [x] Tests pass locally
- [x] PHPCS passes (PSR-12)
- [x] PHPStan passes (level 8)
- [x] Rector passes
- [x] E2E tests verified against real RabbitMQ
- [x] CI passes

Closes #161