### PR TITLE
test: add unit tests for VO classes (KeyValue, Broker, StreamMetadata, Statistic, CommandVersion, PublishingError)

### DIFF
--- a/tests/VO/BrokerTest.php
+++ b/tests/VO/BrokerTest.php
@@ -78,7 +78,7 @@ class BrokerTest extends TestCase
     {
         $buffer = new ReadBuffer(
             pack('n', 1)            // reference (uint16)
-            . pack('n', 0xFFFF)     // host: null (-1 as uint16)
+            . pack('n', 0xFFFF)     // host: null length indicator (0xFFFF = -1 as uint16)
             . pack('N', 5552)        // port (uint32)
         );
         $broker = Broker::fromStreamBuffer($buffer);

--- a/tests/VO/BrokerTest.php
+++ b/tests/VO/BrokerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\Broker;
+use PHPUnit\Framework\TestCase;
+
+class BrokerTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $broker = new Broker(1, 'localhost', 5552);
+        $this->assertSame(1, $broker->getReference());
+        $this->assertSame('localhost', $broker->getHost());
+        $this->assertSame(5552, $broker->getPort());
+    }
+
+    public function testZeroValues(): void
+    {
+        $broker = new Broker(0, '', 0);
+        $this->assertSame(0, $broker->getReference());
+        $this->assertSame('', $broker->getHost());
+        $this->assertSame(0, $broker->getPort());
+    }
+
+    public function testLargeValues(): void
+    {
+        $broker = new Broker(65535, 'node-42.example.com', 4294967295);
+        $this->assertSame(65535, $broker->getReference());
+        $this->assertSame('node-42.example.com', $broker->getHost());
+        $this->assertSame(4294967295, $broker->getPort());
+    }
+
+    public function testFromStreamBuffer(): void
+    {
+        $buffer = new ReadBuffer(
+            pack('n', 5)           // reference (uint16)
+            . pack('n', 6)         // host length (uint16)
+            . 'host-1'              // host
+            . pack('N', 5552)       // port (uint32)
+        );
+        $broker = Broker::fromStreamBuffer($buffer);
+        $this->assertNotNull($broker);
+        $this->assertSame(5, $broker->getReference());
+        $this->assertSame('host-1', $broker->getHost());
+        $this->assertSame(5552, $broker->getPort());
+    }
+
+    public function testToArray(): void
+    {
+        $broker = new Broker(3, 'rabbit-1', 5552);
+        $this->assertSame(['reference' => 3, 'host' => 'rabbit-1', 'port' => 5552], $broker->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $broker = Broker::fromArray(['reference' => 7, 'host' => 'node-3', 'port' => 5552]);
+        $this->assertInstanceOf(Broker::class, $broker);
+        $this->assertSame(7, $broker->getReference());
+        $this->assertSame('node-3', $broker->getHost());
+        $this->assertSame(5552, $broker->getPort());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $broker = new Broker(42, 'my-host.local', 61616);
+        $array = $broker->toArray();
+        $restored = Broker::fromArray($array);
+        $this->assertSame(42, $restored->getReference());
+        $this->assertSame('my-host.local', $restored->getHost());
+        $this->assertSame(61616, $restored->getPort());
+    }
+
+    public function testFromStreamBufferNullHost(): void
+    {
+        $buffer = new ReadBuffer(
+            pack('n', 1)            // reference (uint16)
+            . pack('n', 0xFFFF)     // host: null (-1 as uint16)
+            . pack('N', 5552)        // port (uint32)
+        );
+        $broker = Broker::fromStreamBuffer($buffer);
+        $this->assertNotNull($broker);
+        $this->assertSame(1, $broker->getReference());
+        $this->assertSame('', $broker->getHost());
+        $this->assertSame(5552, $broker->getPort());
+    }
+}

--- a/tests/VO/CommandVersionTest.php
+++ b/tests/VO/CommandVersionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\CommandVersion;
+use PHPUnit\Framework\TestCase;
+
+class CommandVersionTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $cv = new CommandVersion(0x0001, 1, 1);
+        $this->assertSame(0x0001, $cv->getKey());
+        $this->assertSame(1, $cv->getMinVersion());
+        $this->assertSame(1, $cv->getMaxVersion());
+    }
+
+    public function testVersionRange(): void
+    {
+        $cv = new CommandVersion(0x0003, 1, 2);
+        $this->assertSame(1, $cv->getMinVersion());
+        $this->assertSame(2, $cv->getMaxVersion());
+    }
+
+    public function testZeroValues(): void
+    {
+        $cv = new CommandVersion(0, 0, 0);
+        $this->assertSame(0, $cv->getKey());
+        $this->assertSame(0, $cv->getMinVersion());
+        $this->assertSame(0, $cv->getMaxVersion());
+    }
+
+    public function testMaxUint16Values(): void
+    {
+        $cv = new CommandVersion(0xFFFF, 0xFFFF, 0xFFFF);
+        $this->assertSame(0xFFFF, $cv->getKey());
+        $this->assertSame(0xFFFF, $cv->getMinVersion());
+        $this->assertSame(0xFFFF, $cv->getMaxVersion());
+    }
+
+    public function testMinVersionGreaterThanMaxVersion(): void
+    {
+        // This should be allowed at value-object level (protocol validation is separate)
+        $cv = new CommandVersion(0x0010, 3, 1);
+        $this->assertSame(3, $cv->getMinVersion());
+        $this->assertSame(1, $cv->getMaxVersion());
+    }
+
+    public function testRoundTripSerialization(): void
+    {
+        $cv = new CommandVersion(0x8001, 1, 3);
+        $binary = $cv->toStreamBuffer()->getContents();
+        $deserialized = CommandVersion::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame(0x8001, $deserialized->getKey());
+        $this->assertSame(1, $deserialized->getMinVersion());
+        $this->assertSame(3, $deserialized->getMaxVersion());
+    }
+
+    public function testBinarySerializationFormat(): void
+    {
+        $cv = new CommandVersion(0x0015, 2, 5);
+        $binary = $cv->toStreamBuffer()->getContents();
+        // Format: uint16 + uint16 + uint16 = 6 bytes
+        $this->assertSame(6, strlen($binary));
+        $expected = pack('n', 0x0015) . pack('n', 2) . pack('n', 5);
+        $this->assertSame($expected, $binary);
+    }
+
+    public function testToArray(): void
+    {
+        $cv = new CommandVersion(0x0002, 1, 5);
+        $this->assertSame(['key' => 0x0002, 'minVersion' => 1, 'maxVersion' => 5], $cv->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $cv = CommandVersion::fromArray(['key' => 0x8011, 'minVersion' => 1, 'maxVersion' => 1]);
+        $this->assertInstanceOf(CommandVersion::class, $cv);
+        $this->assertSame(0x8011, $cv->getKey());
+        $this->assertSame(1, $cv->getMinVersion());
+        $this->assertSame(1, $cv->getMaxVersion());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $cv = new CommandVersion(0x001A, 1, 2);
+        $array = $cv->toArray();
+        $restored = CommandVersion::fromArray($array);
+        $this->assertSame(0x001A, $restored->getKey());
+        $this->assertSame(1, $restored->getMinVersion());
+        $this->assertSame(2, $restored->getMaxVersion());
+    }
+}

--- a/tests/VO/KeyValueTest.php
+++ b/tests/VO/KeyValueTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\KeyValue;
+use PHPUnit\Framework\TestCase;
+
+class KeyValueTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $kv = new KeyValue('key1', 'value1');
+        $this->assertSame('key1', $kv->getKey());
+        $this->assertSame('value1', $kv->getValue());
+    }
+
+    public function testNullValue(): void
+    {
+        $kv = new KeyValue('key', null);
+        $this->assertSame('key', $kv->getKey());
+        $this->assertNull($kv->getValue());
+    }
+
+    public function testEmptyStringKeyAndValue(): void
+    {
+        $kv = new KeyValue('', '');
+        $this->assertSame('', $kv->getKey());
+        $this->assertSame('', $kv->getValue());
+    }
+
+    public function testRoundTripSerialization(): void
+    {
+        $kv = new KeyValue('my-key', 'my-value');
+        $binary = $kv->toStreamBuffer()->getContents();
+        $deserialized = KeyValue::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame('my-key', $deserialized->getKey());
+        $this->assertSame('my-value', $deserialized->getValue());
+    }
+
+    public function testRoundTripSerializationWithNullValue(): void
+    {
+        $kv = new KeyValue('key-only', null);
+        $binary = $kv->toStreamBuffer()->getContents();
+        $deserialized = KeyValue::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame('key-only', $deserialized->getKey());
+        $this->assertNull($deserialized->getValue());
+    }
+
+    public function testRoundTripSerializationWithEmptyStrings(): void
+    {
+        $kv = new KeyValue('', '');
+        $binary = $kv->toStreamBuffer()->getContents();
+        $deserialized = KeyValue::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame('', $deserialized->getKey());
+        $this->assertSame('', $deserialized->getValue());
+    }
+
+    public function testToArray(): void
+    {
+        $kv = new KeyValue('key', 'value');
+        $this->assertSame(['key' => 'key', 'value' => 'value'], $kv->toArray());
+    }
+
+    public function testToArrayWithNullValue(): void
+    {
+        $kv = new KeyValue('key', null);
+        $this->assertSame(['key' => 'key', 'value' => null], $kv->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $kv = KeyValue::fromArray(['key' => 'my-key', 'value' => 'my-value']);
+        $this->assertInstanceOf(KeyValue::class, $kv);
+        $this->assertSame('my-key', $kv->getKey());
+        $this->assertSame('my-value', $kv->getValue());
+    }
+
+    public function testFromArrayWithNullValue(): void
+    {
+        $kv = KeyValue::fromArray(['key' => 'my-key', 'value' => null]);
+        $this->assertInstanceOf(KeyValue::class, $kv);
+        $this->assertSame('my-key', $kv->getKey());
+        $this->assertNull($kv->getValue());
+    }
+
+    public function testFromArrayWithMissingValue(): void
+    {
+        $kv = KeyValue::fromArray(['key' => 'my-key']);
+        $this->assertInstanceOf(KeyValue::class, $kv);
+        $this->assertSame('my-key', $kv->getKey());
+        $this->assertNull($kv->getValue());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $kv = new KeyValue('round-trip', 'works');
+        $array = $kv->toArray();
+        $restored = KeyValue::fromArray($array);
+        $this->assertSame('round-trip', $restored->getKey());
+        $this->assertSame('works', $restored->getValue());
+    }
+
+    public function testBinarySerializationFormat(): void
+    {
+        $kv = new KeyValue('ab', 'cd');
+        $binary = $kv->toStreamBuffer()->getContents();
+        // Format: uint16(2) + "ab" + uint16(2) + "cd"
+        $this->assertSame(8, strlen($binary));
+        $expected = pack('n', 2) . 'ab' . pack('n', 2) . 'cd';
+        $this->assertSame($expected, $binary);
+    }
+
+    public function testBinarySerializationFormatNullValue(): void
+    {
+        $kv = new KeyValue('ab', null);
+        $binary = $kv->toStreamBuffer()->getContents();
+        // Format: uint16(2) + "ab" + uint16(0xFFFF) (-1 as null)
+        $this->assertSame(6, strlen($binary));
+        $expected = pack('n', 2) . 'ab' . pack('n', 0xFFFF);
+        $this->assertSame($expected, $binary);
+    }
+}

--- a/tests/VO/PublishingErrorTest.php
+++ b/tests/VO/PublishingErrorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\PublishingError;
+use PHPUnit\Framework\TestCase;
+
+class PublishingErrorTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $err = new PublishingError(42, 0x0001);
+        $this->assertSame(42, $err->getPublishingId());
+        $this->assertSame(0x0001, $err->getCode());
+    }
+
+    public function testZeroPublishingId(): void
+    {
+        $err = new PublishingError(0, 0x0002);
+        $this->assertSame(0, $err->getPublishingId());
+        $this->assertSame(0x0002, $err->getCode());
+    }
+
+    public function testLargePublishingId(): void
+    {
+        $err = new PublishingError(9223372036854775807, 0xFFFF);
+        $this->assertSame(9223372036854775807, $err->getPublishingId());
+        $this->assertSame(0xFFFF, $err->getCode());
+    }
+
+    public function testFromStreamBuffer(): void
+    {
+        $buffer = new ReadBuffer(
+            pack('J', 100)     // publishingId (uint64)
+            . pack('n', 7)     // code (uint16)
+        );
+        $err = PublishingError::fromStreamBuffer($buffer);
+        $this->assertNotNull($err);
+        $this->assertSame(100, $err->getPublishingId());
+        $this->assertSame(7, $err->getCode());
+    }
+
+    public function testToArray(): void
+    {
+        $err = new PublishingError(42, 0x0001);
+        $this->assertSame(['publishingId' => 42, 'code' => 0x0001], $err->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $err = PublishingError::fromArray(['publishingId' => 99, 'code' => 0x0003]);
+        $this->assertInstanceOf(PublishingError::class, $err);
+        $this->assertSame(99, $err->getPublishingId());
+        $this->assertSame(0x0003, $err->getCode());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $err = new PublishingError(777, 0x0005);
+        $array = $err->toArray();
+        $restored = PublishingError::fromArray($array);
+        $this->assertSame(777, $restored->getPublishingId());
+        $this->assertSame(0x0005, $restored->getCode());
+    }
+}

--- a/tests/VO/StatisticTest.php
+++ b/tests/VO/StatisticTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\Statistic;
+use PHPUnit\Framework\TestCase;
+
+class StatisticTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $stat = new Statistic('messages', 42);
+        $this->assertSame('messages', $stat->getKey());
+        $this->assertSame(42, $stat->getValue());
+    }
+
+    public function testZeroValue(): void
+    {
+        $stat = new Statistic('offset', 0);
+        $this->assertSame('offset', $stat->getKey());
+        $this->assertSame(0, $stat->getValue());
+    }
+
+    public function testLargeValue(): void
+    {
+        $stat = new Statistic('big-number', 9223372036854775807);
+        $this->assertSame(9223372036854775807, $stat->getValue());
+    }
+
+    public function testNegativeValue(): void
+    {
+        $stat = new Statistic('deficit', -100);
+        $this->assertSame(-100, $stat->getValue());
+    }
+
+    public function testEmptyKey(): void
+    {
+        $stat = new Statistic('', 1);
+        $this->assertSame('', $stat->getKey());
+        $this->assertSame(1, $stat->getValue());
+    }
+
+    public function testRoundTripSerialization(): void
+    {
+        $stat = new Statistic('my-stat', 12345);
+        $binary = $stat->toStreamBuffer()->getContents();
+        $deserialized = Statistic::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame('my-stat', $deserialized->getKey());
+        $this->assertSame(12345, $deserialized->getValue());
+    }
+
+    public function testRoundTripSerializationNegative(): void
+    {
+        $stat = new Statistic('negative', -42);
+        $binary = $stat->toStreamBuffer()->getContents();
+        $deserialized = Statistic::fromStreamBuffer(new ReadBuffer($binary));
+        $this->assertNotNull($deserialized);
+        $this->assertSame(-42, $deserialized->getValue());
+    }
+
+    public function testBinarySerializationFormat(): void
+    {
+        $stat = new Statistic('ab', 99);
+        $binary = $stat->toStreamBuffer()->getContents();
+        // Format: uint16(2) + "ab" + int64(99)
+        $this->assertSame(2 + 2 + 8, strlen($binary));
+        $expected = pack('n', 2) . 'ab' . pack('J', 99);
+        $this->assertSame($expected, $binary);
+    }
+
+    public function testToArray(): void
+    {
+        $stat = new Statistic('consumers', 5);
+        $this->assertSame(['key' => 'consumers', 'value' => 5], $stat->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $stat = Statistic::fromArray(['key' => 'connections', 'value' => 10]);
+        $this->assertInstanceOf(Statistic::class, $stat);
+        $this->assertSame('connections', $stat->getKey());
+        $this->assertSame(10, $stat->getValue());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $stat = new Statistic('chunks', 999);
+        $array = $stat->toArray();
+        $restored = Statistic::fromArray($array);
+        $this->assertSame('chunks', $restored->getKey());
+        $this->assertSame(999, $restored->getValue());
+    }
+}

--- a/tests/VO/StreamMetadataTest.php
+++ b/tests/VO/StreamMetadataTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\VO;
+
+use CrazyGoat\RabbitStream\Buffer\ReadBuffer;
+use CrazyGoat\RabbitStream\VO\StreamMetadata;
+use PHPUnit\Framework\TestCase;
+
+class StreamMetadataTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $meta = new StreamMetadata('my-stream', 0x0001, 5, [3, 7]);
+        $this->assertSame('my-stream', $meta->getStreamName());
+        $this->assertSame(0x0001, $meta->getResponseCode());
+        $this->assertSame(5, $meta->getLeaderReference());
+        $this->assertSame([3, 7], $meta->getReplicasReferences());
+    }
+
+    public function testEmptyReplicas(): void
+    {
+        $meta = new StreamMetadata('single-node', 0x0001, 0, []);
+        $this->assertSame('single-node', $meta->getStreamName());
+        $this->assertSame([], $meta->getReplicasReferences());
+    }
+
+    public function testZeroResponseCode(): void
+    {
+        $meta = new StreamMetadata('not-found', 0x0000, 0, []);
+        $this->assertSame(0x0000, $meta->getResponseCode());
+    }
+
+    public function testSingleReplica(): void
+    {
+        $meta = new StreamMetadata('with-replica', 0x0001, 1, [2]);
+        $this->assertCount(1, $meta->getReplicasReferences());
+        $this->assertSame([2], $meta->getReplicasReferences());
+    }
+
+    public function testMultipleReplicas(): void
+    {
+        $replicas = [10, 20, 30, 40, 50];
+        $meta = new StreamMetadata('multi-replica', 0x0001, 5, $replicas);
+        $this->assertCount(5, $meta->getReplicasReferences());
+        $this->assertSame($replicas, $meta->getReplicasReferences());
+    }
+
+    public function testFromStreamBufferWithoutReplicas(): void
+    {
+        $streamName = 'stream-no-replicas';
+        $buffer = new ReadBuffer(
+            pack('n', strlen($streamName))  // stream name length
+            . $streamName
+            . pack('n', 0x0001)             // response code (uint16)
+            . pack('n', 0)                  // leader reference (uint16)
+            . pack('N', 0)                  // replicas count (uint32)
+        );
+        $meta = StreamMetadata::fromStreamBuffer($buffer);
+        $this->assertNotNull($meta);
+        $this->assertSame($streamName, $meta->getStreamName());
+        $this->assertSame(0x0001, $meta->getResponseCode());
+        $this->assertSame(0, $meta->getLeaderReference());
+        $this->assertSame([], $meta->getReplicasReferences());
+    }
+
+    public function testFromStreamBufferWithReplicas(): void
+    {
+        $streamName = 'stream-replicas';
+        $buffer = new ReadBuffer(
+            pack('n', strlen($streamName))  // stream name length
+            . $streamName
+            . pack('n', 0x0001)             // response code (uint16)
+            . pack('n', 3)                  // leader reference (uint16)
+            . pack('N', 2)                  // replicas count (uint32)
+            . pack('n', 7)                  // replica 1 (uint16)
+            . pack('n', 9)                  // replica 2 (uint16)
+        );
+        $meta = StreamMetadata::fromStreamBuffer($buffer);
+        $this->assertNotNull($meta);
+        $this->assertSame($streamName, $meta->getStreamName());
+        $this->assertSame([7, 9], $meta->getReplicasReferences());
+    }
+
+    public function testToArray(): void
+    {
+        $meta = new StreamMetadata('s1', 0x0001, 2, [5, 8]);
+        $this->assertSame([
+            'stream' => 's1',
+            'responseCode' => 0x0001,
+            'leaderReference' => 2,
+            'replicasReferences' => [5, 8],
+        ], $meta->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $meta = StreamMetadata::fromArray([
+            'stream' => 'arr-stream',
+            'responseCode' => 0x0001,
+            'leaderReference' => 99,
+            'replicasReferences' => [11, 22],
+        ]);
+        $this->assertInstanceOf(StreamMetadata::class, $meta);
+        $this->assertSame('arr-stream', $meta->getStreamName());
+        $this->assertSame(99, $meta->getLeaderReference());
+        $this->assertSame([11, 22], $meta->getReplicasReferences());
+    }
+
+    public function testFromArrayWithDefaultReplicas(): void
+    {
+        $meta = StreamMetadata::fromArray([
+            'stream' => 'default-replicas',
+            'responseCode' => 0x0001,
+            'leaderReference' => 0,
+        ]);
+        $this->assertSame([], $meta->getReplicasReferences());
+    }
+
+    public function testToArrayFromArrayRoundTrip(): void
+    {
+        $meta = new StreamMetadata('round-trip', 0x0001, 42, [1, 2, 3]);
+        $array = $meta->toArray();
+        $restored = StreamMetadata::fromArray($array);
+        $this->assertSame('round-trip', $restored->getStreamName());
+        $this->assertSame(42, $restored->getLeaderReference());
+        $this->assertSame([1, 2, 3], $restored->getReplicasReferences());
+    }
+
+    public function testFromStreamBufferNullStreamName(): void
+    {
+        $buffer = new ReadBuffer(
+            pack('n', 0xFFFF)               // stream name: null
+            . pack('n', 0x0001)              // response code (uint16)
+            . pack('n', 0)                   // leader reference (uint16)
+            . pack('N', 0)                   // replicas count (uint32)
+        );
+        $meta = StreamMetadata::fromStreamBuffer($buffer);
+        $this->assertNotNull($meta);
+        $this->assertSame('', $meta->getStreamName());
+    }
+}

--- a/tests/VO/StreamMetadataTest.php
+++ b/tests/VO/StreamMetadataTest.php
@@ -80,6 +80,8 @@ class StreamMetadataTest extends TestCase
         $meta = StreamMetadata::fromStreamBuffer($buffer);
         $this->assertNotNull($meta);
         $this->assertSame($streamName, $meta->getStreamName());
+        $this->assertSame(0x0001, $meta->getResponseCode());
+        $this->assertSame(3, $meta->getLeaderReference());
         $this->assertSame([7, 9], $meta->getReplicasReferences());
     }
 


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for 6 Value Object classes that previously had no direct test coverage.

## Changes

### New test files
- `tests/VO/KeyValueTest.php` — serialization round-trip, binary format, toArray/fromArray, null value handling
- `tests/VO/BrokerTest.php` — fromStreamBuffer, toArray/fromArray, null host handling
- `tests/VO/StreamMetadataTest.php` — fromStreamBuffer with/without replicas, toArray/fromArray, edge cases
- `tests/VO/StatisticTest.php` — serialization round-trip (including negative values), binary format, toArray/fromArray
- `tests/VO/CommandVersionTest.php` — serialization round-trip, binary format, version range, max uint16 values
- `tests/VO/PublishingErrorTest.php` — fromStreamBuffer, toArray/fromArray, large publishing IDs

### Coverage provided
- Serialization round-trip (binary → object → binary) for all serializable VOs
- toArray()/fromArray() round-trip for all VOs
- Edge cases: null values, empty strings, zero values, large numbers, negative values
- Binary format verification with pack() assertions

Closes #190