### PR TITLE
Test quality: Add stream cleanup in tearDown() for low-level protocol tests (#179)

### DIFF
--- a/tests/E2E/CreateStreamTest.php
+++ b/tests/E2E/CreateStreamTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Exception\ProtocolException;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
@@ -20,11 +21,30 @@ class CreateStreamTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $streamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->streamName !== '') {
+                $this->connection->sendMessage(new DeleteStreamRequestV1($this->streamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -53,47 +73,38 @@ class CreateStreamTest extends TestCase
 
     public function testCreateStream(): void
     {
-        $connection = $this->connectAndOpen();
-
-        $streamName = 'test-create-stream-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $response = $connection->readMessage();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-create-stream-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(CreateResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testCreateStreamWithArguments(): void
     {
-        $connection = $this->connectAndOpen();
-
-        $streamName = 'test-create-stream-args-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName, [
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-create-stream-args-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName, [
             'max-length-bytes' => '1000000',
             'max-age' => '1h',
         ]));
-        $response = $connection->readMessage();
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(CreateResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testCreateDuplicateStreamThrows(): void
     {
-        $connection = $this->connectAndOpen();
-
-        $streamName = 'test-create-duplicate-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-create-duplicate-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
         // Second create should fail with STREAM_ALREADY_EXISTS (0x05)
         $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage('STREAM_ALREADY_EXISTS');
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
     }
 }

--- a/tests/E2E/CreateSuperStreamTest.php
+++ b/tests/E2E/CreateSuperStreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PartitionsRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
@@ -20,11 +21,30 @@ class CreateSuperStreamTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $superStreamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->superStreamName !== '') {
+                $this->connection->sendMessage(new DeleteSuperStreamRequestV1($this->superStreamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — super stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -53,26 +73,26 @@ class CreateSuperStreamTest extends TestCase
 
     public function testCreateSuperStream(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
 
-        $superStreamName = 'test-super-stream-' . uniqid();
-        $partition1 = $superStreamName . '-partition1';
-        $partition2 = $superStreamName . '-partition2';
-        $partition3 = $superStreamName . '-partition3';
+        $this->superStreamName = 'test-super-stream-' . uniqid();
+        $partition1 = $this->superStreamName . '-partition1';
+        $partition2 = $this->superStreamName . '-partition2';
+        $partition3 = $this->superStreamName . '-partition3';
 
-        $connection->sendMessage(new CreateSuperStreamRequestV1(
-            $superStreamName,
+        $this->connection->sendMessage(new CreateSuperStreamRequestV1(
+            $this->superStreamName,
             [$partition1, $partition2, $partition3],
             ['key1', 'key2', 'key3'],
             ['max-length-bytes' => '1000000']
         ));
-        $response = $connection->readMessage();
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(CreateSuperStreamResponseV1::class, $response);
 
         // Verify we can query partitions
-        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
-        $partitionsResponse = $connection->readMessage();
+        $this->connection->sendMessage(new PartitionsRequestV1($this->superStreamName));
+        $partitionsResponse = $this->connection->readMessage();
 
         $this->assertInstanceOf(PartitionsResponseV1::class, $partitionsResponse);
         $streams = $partitionsResponse->getStreams();
@@ -80,33 +100,29 @@ class CreateSuperStreamTest extends TestCase
         $this->assertContains($partition1, $streams);
         $this->assertContains($partition2, $streams);
         $this->assertContains($partition3, $streams);
-
-        $connection->close();
     }
 
     public function testCreateDuplicateSuperStreamThrows(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
 
-        $superStreamName = 'test-duplicate-super-stream-' . uniqid();
+        $this->superStreamName = 'test-duplicate-super-stream-' . uniqid();
 
         // First create should succeed
-        $connection->sendMessage(new CreateSuperStreamRequestV1(
-            $superStreamName,
-            [$superStreamName . '-p1', $superStreamName . '-p2'],
+        $this->connection->sendMessage(new CreateSuperStreamRequestV1(
+            $this->superStreamName,
+            [$this->superStreamName . '-p1', $this->superStreamName . '-p2'],
             ['k1', 'k2']
         ));
-        $connection->readMessage();
+        $this->connection->readMessage();
 
         // Second create should fail
         $this->expectException(\Exception::class);
-        $connection->sendMessage(new CreateSuperStreamRequestV1(
-            $superStreamName,
-            [$superStreamName . '-p1', $superStreamName . '-p2'],
+        $this->connection->sendMessage(new CreateSuperStreamRequestV1(
+            $this->superStreamName,
+            [$this->superStreamName . '-p1', $this->superStreamName . '-p2'],
             ['k1', 'k2']
         ));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->readMessage();
     }
 }

--- a/tests/E2E/PartitionsTest.php
+++ b/tests/E2E/PartitionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PartitionsRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
@@ -20,11 +21,30 @@ class PartitionsTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $superStreamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->superStreamName !== '') {
+                $this->connection->sendMessage(new DeleteSuperStreamRequestV1($this->superStreamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — super stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -53,35 +73,32 @@ class PartitionsTest extends TestCase
 
     public function testPartitionsForNonExistentSuperStreamThrows(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
 
         $superStreamName = 'test-nonexistent-partitions-' . uniqid();
 
         $this->expectException(\Exception::class);
-        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new PartitionsRequestV1($superStreamName));
+        $this->connection->readMessage();
     }
 
     public function testPartitionsReturnsStreamsForSuperStream(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->superStreamName = 'test-partitions-super-stream-' . uniqid();
+        $partition1 = $this->superStreamName . '-0';
+        $partition2 = $this->superStreamName . '-1';
+        $partition3 = $this->superStreamName . '-2';
 
-        $superStreamName = 'test-partitions-super-stream-' . uniqid();
-        $partition1 = $superStreamName . '-0';
-        $partition2 = $superStreamName . '-1';
-        $partition3 = $superStreamName . '-2';
-
-        $connection->sendMessage(new CreateSuperStreamRequestV1(
-            $superStreamName,
+        $this->connection->sendMessage(new CreateSuperStreamRequestV1(
+            $this->superStreamName,
             [$partition1, $partition2, $partition3],
             ['0', '1', '2']
         ));
-        $connection->readMessage();
+        $this->connection->readMessage();
 
-        $connection->sendMessage(new PartitionsRequestV1($superStreamName));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new PartitionsRequestV1($this->superStreamName));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(PartitionsResponseV1::class, $response);
         $streams = $response->getStreams();
@@ -89,7 +106,5 @@ class PartitionsTest extends TestCase
         $this->assertContains($partition1, $streams);
         $this->assertContains($partition2, $streams);
         $this->assertContains($partition3, $streams);
-
-        $connection->close();
     }
 }

--- a/tests/E2E/QueryPublisherSequenceTest.php
+++ b/tests/E2E/QueryPublisherSequenceTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
 use CrazyGoat\RabbitStream\Request\DeclarePublisherRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\PublishRequestV1;
@@ -25,11 +26,30 @@ class QueryPublisherSequenceTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $streamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->streamName !== '') {
+                $this->connection->sendMessage(new DeleteStreamRequestV1($this->streamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -58,64 +78,60 @@ class QueryPublisherSequenceTest extends TestCase
 
     public function testQueryPublisherSequenceReturnsZeroForNewPublisher(): void
     {
-        $connection = $this->connectAndOpen();
-        $stream = 'test-query-pub-seq-stream-1';
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-query-pub-seq-stream-' . uniqid();
         $publisherRef = 'test-publisher-ref-1';
 
         // Create stream
-        $connection->sendMessage(new CreateRequestV1($stream, []));
-        $createResponse = $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName, []));
+        $createResponse = $this->connection->readMessage();
         $this->assertInstanceOf(CreateResponseV1::class, $createResponse);
 
         // Declare publisher with reference
-        $connection->sendMessage(new DeclarePublisherRequestV1(1, $publisherRef, $stream));
-        $declareResponse = $connection->readMessage();
+        $this->connection->sendMessage(new DeclarePublisherRequestV1(1, $publisherRef, $this->streamName));
+        $declareResponse = $this->connection->readMessage();
         $this->assertInstanceOf(DeclarePublisherResponseV1::class, $declareResponse);
 
         // Query sequence before publishing
-        $connection->sendMessage(new QueryPublisherSequenceRequestV1($publisherRef, $stream));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new QueryPublisherSequenceRequestV1($publisherRef, $this->streamName));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(QueryPublisherSequenceResponseV1::class, $response);
         $this->assertSame(0, $response->getSequence());
-
-        $connection->close();
     }
 
     public function testQueryPublisherSequenceReturnsLastPublishedId(): void
     {
-        $connection = $this->connectAndOpen();
-        $stream = 'test-query-pub-seq-stream-2';
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-query-pub-seq-stream-' . uniqid();
         $publisherRef = 'test-publisher-ref-2';
 
         // Create stream
-        $connection->sendMessage(new CreateRequestV1($stream, []));
-        $createResponse = $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName, []));
+        $createResponse = $this->connection->readMessage();
         $this->assertInstanceOf(CreateResponseV1::class, $createResponse);
 
         // Declare publisher
-        $connection->sendMessage(new DeclarePublisherRequestV1(1, $publisherRef, $stream));
-        $declareResponse = $connection->readMessage();
+        $this->connection->sendMessage(new DeclarePublisherRequestV1(1, $publisherRef, $this->streamName));
+        $declareResponse = $this->connection->readMessage();
         $this->assertInstanceOf(DeclarePublisherResponseV1::class, $declareResponse);
 
         // Register publisher callback to handle PublishConfirm
         $confirmed = false;
-        $connection->registerPublisher(1, function () use (&$confirmed): void {
+        $this->connection->registerPublisher(1, function () use (&$confirmed): void {
             $confirmed = true;
         }, function (): void {
         });
 
         // Publish a message with publishingId = 5
-        $connection->sendMessage(new PublishRequestV1(1, new PublishedMessage(5, 'test message')));
-        $connection->readLoop(maxFrames: 1); // Wait for PublishConfirm
+        $this->connection->sendMessage(new PublishRequestV1(1, new PublishedMessage(5, 'test message')));
+        $this->connection->readLoop(maxFrames: 1); // Wait for PublishConfirm
 
         // Query sequence - should return 5
-        $connection->sendMessage(new QueryPublisherSequenceRequestV1($publisherRef, $stream));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new QueryPublisherSequenceRequestV1($publisherRef, $this->streamName));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(QueryPublisherSequenceResponseV1::class, $response);
         $this->assertSame(5, $response->getSequence());
-
-        $connection->close();
     }
 }

--- a/tests/E2E/SubscribeTest.php
+++ b/tests/E2E/SubscribeTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Exception\ProtocolException;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
@@ -23,11 +24,30 @@ class SubscribeTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $streamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->streamName !== '') {
+                $this->connection->sendMessage(new DeleteStreamRequestV1($this->streamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -56,86 +76,78 @@ class SubscribeTest extends TestCase
 
     public function testSubscribeToStream(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-subscribe-stream-' . uniqid();
 
         // Create a test stream
-        $streamName = 'test-subscribe-stream-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $createResponse = $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $createResponse = $this->connection->readMessage();
         $this->assertInstanceOf(CreateResponseV1::class, $createResponse);
 
         // Subscribe to the stream
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::first(), 10));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::first(), 10));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(SubscribeResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testSubscribeWithOffsetLast(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-subscribe-last-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
-        $streamName = 'test-subscribe-last-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
-
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::last(), 5));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::last(), 5));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(SubscribeResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testSubscribeWithOffsetNext(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-subscribe-next-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
-        $streamName = 'test-subscribe-next-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
-
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::next(), 20));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::next(), 20));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(SubscribeResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testSubscribeToNonExistentStreamThrows(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
 
         $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage('STREAM_NOT_EXIST');
-        $connection->sendMessage(new SubscribeRequestV1(1, 'non-existent-stream-' . uniqid(), OffsetSpec::first(), 10));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new SubscribeRequestV1(
+            1,
+            'non-existent-stream-' . uniqid(),
+            OffsetSpec::first(),
+            10
+        ));
+        $this->connection->readMessage();
     }
 
     public function testDuplicateSubscriptionIdThrows(): void
     {
-        $connection = $this->connectAndOpen();
-
-        $streamName = 'test-subscribe-duplicate-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-subscribe-duplicate-' . uniqid();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
         // First subscription should succeed
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::first(), 10));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::first(), 10));
+        $response = $this->connection->readMessage();
         $this->assertInstanceOf(SubscribeResponseV1::class, $response);
 
         // Second subscription with same ID should fail with SUBSCRIPTION_ID_ALREADY_EXISTS (0x03)
         $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage('SUBSCRIPTION_ID_ALREADY_EXISTS');
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::first(), 10));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::first(), 10));
+        $this->connection->readMessage();
     }
 }

--- a/tests/E2E/UnsubscribeTest.php
+++ b/tests/E2E/UnsubscribeTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Exception\ProtocolException;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
@@ -25,11 +26,30 @@ class UnsubscribeTest extends TestCase
 {
     private static string $host = '127.0.0.1';
     private static int $port = 5552;
+    private ?StreamConnection $connection = null;
+    private string $streamName = '';
 
     public static function setUpBeforeClass(): void
     {
         self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!$this->connection instanceof StreamConnection) {
+            return;
+        }
+        try {
+            if ($this->connection->isConnected() && $this->streamName !== '') {
+                $this->connection->sendMessage(new DeleteStreamRequestV1($this->streamName));
+                $this->connection->readMessage();
+            }
+        } catch (\Exception) {
+            // Ignore cleanup errors — stream may already be deleted
+        } finally {
+            $this->connection->close();
+        }
     }
 
     private function connectAndOpen(): StreamConnection
@@ -58,71 +78,65 @@ class UnsubscribeTest extends TestCase
 
     public function testUnsubscribeFromStream(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-unsubscribe-stream-' . uniqid();
 
         // Create a test stream
-        $streamName = 'test-unsubscribe-stream-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $createResponse = $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $createResponse = $this->connection->readMessage();
         $this->assertInstanceOf(CreateResponseV1::class, $createResponse);
 
         // Subscribe to the stream
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::first(), 10));
-        $subscribeResponse = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::first(), 10));
+        $subscribeResponse = $this->connection->readMessage();
         $this->assertInstanceOf(SubscribeResponseV1::class, $subscribeResponse);
 
         // Unsubscribe from the stream
-        $connection->sendMessage(new UnsubscribeRequestV1(1));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new UnsubscribeRequestV1(1));
+        $response = $this->connection->readMessage();
 
         $this->assertInstanceOf(UnsubscribeResponseV1::class, $response);
-
-        $connection->close();
     }
 
     public function testUnsubscribeNonExistentSubscriptionThrows(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-unsubscribe-non-existent-' . uniqid();
 
         // Create a test stream
-        $streamName = 'test-unsubscribe-non-existent-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
         // Try to unsubscribe without subscribing first — should get SUBSCRIPTION_ID_NOT_EXIST (0x04)
         $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage('SUBSCRIPTION_ID_NOT_EXIST');
-        $connection->sendMessage(new UnsubscribeRequestV1(99));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new UnsubscribeRequestV1(99));
+        $this->connection->readMessage();
     }
 
     public function testUnsubscribeAlreadyUnsubscribedThrows(): void
     {
-        $connection = $this->connectAndOpen();
+        $this->connection = $this->connectAndOpen();
+        $this->streamName = 'test-unsubscribe-already-' . uniqid();
 
         // Create a test stream
-        $streamName = 'test-unsubscribe-already-' . uniqid();
-        $connection->sendMessage(new CreateRequestV1($streamName));
-        $connection->readMessage();
+        $this->connection->sendMessage(new CreateRequestV1($this->streamName));
+        $this->connection->readMessage();
 
         // Subscribe
-        $connection->sendMessage(new SubscribeRequestV1(1, $streamName, OffsetSpec::first(), 10));
-        $subscribeResponse = $connection->readMessage();
+        $this->connection->sendMessage(new SubscribeRequestV1(1, $this->streamName, OffsetSpec::first(), 10));
+        $subscribeResponse = $this->connection->readMessage();
         $this->assertInstanceOf(SubscribeResponseV1::class, $subscribeResponse);
 
         // First unsubscribe should succeed
-        $connection->sendMessage(new UnsubscribeRequestV1(1));
-        $response = $connection->readMessage();
+        $this->connection->sendMessage(new UnsubscribeRequestV1(1));
+        $response = $this->connection->readMessage();
         $this->assertInstanceOf(UnsubscribeResponseV1::class, $response);
 
         // Second unsubscribe with same ID should fail with SUBSCRIPTION_ID_NOT_EXIST (0x04)
         $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage('SUBSCRIPTION_ID_NOT_EXIST');
-        $connection->sendMessage(new UnsubscribeRequestV1(1));
-        $connection->readMessage();
-
-        $connection->close();
+        $this->connection->sendMessage(new UnsubscribeRequestV1(1));
+        $this->connection->readMessage();
     }
 }


### PR DESCRIPTION
## Summary

Adds `tearDown()` with stream cleanup to 6 low-level E2E test files. Also fixes `QueryPublisherSequenceTest` which used hardcoded stream names without `uniqid()`.

## Changes

### Stream cleanup in tearDown()
- **CreateStreamTest** — cleans up created streams
- **SubscribeTest** — cleans up created streams  
- **UnsubscribeTest** — cleans up created streams
- **QueryPublisherSequenceTest** — cleans up created streams + uses `uniqid()`
- **CreateSuperStreamTest** — cleans up created super streams via `DeleteSuperStreamRequestV1`
- **PartitionsTest** — cleans up created super streams via `DeleteSuperStreamRequestV1`

### tearDown() pattern
- Guards with null check (early return if no connection)
- Guards with empty stream name check (avoids unnecessary delete for tests that don't create streams)
- Uses try/finally to ensure connection is always closed
- Silently ignores cleanup errors (stream may already be deleted)

### Bug fix
- `QueryPublisherSequenceTest` used hardcoded names (`test-query-pub-seq-stream-1`, `test-query-pub-seq-stream-2`) causing failures on repeated runs. Fixed to use `uniqid()`.

## Acceptance criteria
- [x] All tests that create streams delete them in `tearDown()`
- [x] `QueryPublisherSequenceTest` uses `uniqid()` for stream names
- [x] Tests are idempotent — can run multiple times without failures
- [x] Cleanup errors are silently ignored (stream may already be deleted)

Closes #179
