### PR TITLE
test: add E2E tests for large batch publish (#157)

### DIFF
--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -153,4 +153,66 @@ class ProducerTest extends TestCase
 
         $producer->close();
     }
+
+    public function testLargeBatchPublish(): void
+    {
+        $this->assertNotNull($this->connection);
+        $this->publishBatchAndVerifyConfirms(
+            500,
+            fn(int $i): string => "message-{$i}",
+            30.0
+        );
+    }
+
+    public function testBatchPublishWith1KbMessages(): void
+    {
+        $this->assertNotNull($this->connection);
+        $this->publishBatchAndVerifyConfirms(
+            100,
+            fn(): string => str_repeat('X', 1024),
+            30.0
+        );
+    }
+
+    /**
+     * @param callable(int): string $messageFactory
+     */
+    private function publishBatchAndVerifyConfirms(int $count, callable $messageFactory, float $timeout = 5.0): void
+    {
+        $confirmed = [];
+        $producer = $this->connection->createProducer(
+            $this->streamName,
+            onConfirm: function (ConfirmationStatus $status) use (&$confirmed): void {
+                $confirmed[] = $status;
+            }
+        );
+
+        $messages = [];
+        for ($i = 0; $i < $count; $i++) {
+            $messages[] = $messageFactory($i);
+        }
+
+        $producer->sendBatch($messages);
+        $producer->waitForConfirms(timeout: $timeout);
+
+        $this->assertCount($count, $confirmed);
+
+        $publishingIds = [];
+        foreach ($confirmed as $status) {
+            $this->assertTrue($status->isConfirmed());
+            $id = $status->getPublishingId();
+            if ($id !== null) {
+                $publishingIds[] = $id;
+            }
+        }
+
+        // Verify no gaps in publishing IDs
+        $this->assertCount($count, $publishingIds, 'All confirms should have a publishing ID');
+        sort($publishingIds);
+        $this->assertSame(0, $publishingIds[0], 'First publishing ID should be 0');
+        $this->assertSame($count - 1, $publishingIds[$count - 1], 'Last publishing ID should be ' . ($count - 1));
+        $this->assertCount($count, array_unique($publishingIds), 'All publishing IDs should be unique');
+
+        $producer->close();
+    }
 }

--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -179,6 +179,7 @@ class ProducerTest extends TestCase
      */
     private function publishBatchAndVerifyConfirms(int $count, callable $messageFactory, float $timeout = 5.0): void
     {
+        $this->assertNotNull($this->connection);
         $confirmed = [];
         $producer = $this->connection->createProducer(
             $this->streamName,


### PR DESCRIPTION
## Summary

Adds E2E tests for publishing large batches of messages, addressing issue #157.

## Changes

- **testLargeBatchPublish**: Publish 500 small messages in a single batch, verify all are confirmed with no gaps in publishing IDs
- **testBatchPublishWith1KbMessages**: Publish 100 messages of 1KB each, verify all confirmed with no gaps in IDs
- **publishBatchAndVerifyConfirms()**: Shared private helper to reduce duplication

## Acceptance Criteria

- [x] Batch of 500 small messages → all confirmed
- [x] Batch of 100 medium messages (1KB each) → all confirmed
- [x] Verify all publishing IDs are confirmed (no gaps)
- [x] Test completes within reasonable timeout (< 30s)

## Verification

- [x] Lint (PHPCS) passes
- [x] Unit tests pass (616 tests, all green)