### PR TITLE
feat: add E2E test for readMessage() timeout behavior (#165)

### DIFF
--- a/tests/E2E/ReadMessageTimeoutTest.php
+++ b/tests/E2E/ReadMessageTimeoutTest.php
@@ -6,59 +6,13 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Exception\TimeoutException;
 use CrazyGoat\RabbitStream\Request\CloseRequestV1;
-use CrazyGoat\RabbitStream\Request\OpenRequestV1;
-use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
-use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
-use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
-use CrazyGoat\RabbitStream\Request\TuneRequestV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
-use CrazyGoat\RabbitStream\Response\TuneResponseV1;
-use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\TestCase;
 
-class ReadMessageTimeoutTest extends TestCase
+class ReadMessageTimeoutTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        $host = getenv('RABBITMQ_HOST') ?: self::$host;
-        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-        self::$host = $host;
-        self::$port = $port;
-    }
-
-    private function createConnection(): StreamConnection
-    {
-        $connection = new StreamConnection(self::$host, self::$port);
-        $connection->connect();
-        return $connection;
-    }
-
-    private function performHandshake(StreamConnection $connection): void
-    {
-        $connection->sendMessage(new PeerPropertiesRequestV1());
-        $connection->readMessage();
-
-        $connection->sendMessage(new SaslHandshakeRequestV1());
-        $connection->readMessage();
-
-        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
-        $connection->readMessage();
-
-        $tune = $connection->readMessage();
-        $this->assertInstanceOf(TuneRequestV1::class, $tune);
-        $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
-
-        $connection->sendMessage(new OpenRequestV1('/'));
-        $connection->readMessage();
-    }
-
     public function testReadMessageTimesOutWhenNoDataAvailable(): void
     {
-        $connection = $this->createConnection();
-        $this->performHandshake($connection);
+        $connection = $this->connectAndOpen();
 
         // Don't send any request — readMessage should block and eventually timeout
         $start = microtime(true);
@@ -79,8 +33,7 @@ class ReadMessageTimeoutTest extends TestCase
 
     public function testConnectionRemainsUsableAfterTimeout(): void
     {
-        $connection = $this->createConnection();
-        $this->performHandshake($connection);
+        $connection = $this->connectAndOpen();
 
         // First read should timeout (no pending data)
         try {
@@ -102,8 +55,7 @@ class ReadMessageTimeoutTest extends TestCase
 
     public function testReadMessageWithZeroTimeoutReturnsImmediately(): void
     {
-        $connection = $this->createConnection();
-        $this->performHandshake($connection);
+        $connection = $this->connectAndOpen();
 
         $start = microtime(true);
 

--- a/tests/E2E/ReadMessageTimeoutTest.php
+++ b/tests/E2E/ReadMessageTimeoutTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Exception\TimeoutException;
+use CrazyGoat\RabbitStream\Request\CloseRequestV1;
+use CrazyGoat\RabbitStream\Request\OpenRequestV1;
+use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
+use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
+use CrazyGoat\RabbitStream\Request\TuneRequestV1;
+use CrazyGoat\RabbitStream\Response\CloseResponseV1;
+use CrazyGoat\RabbitStream\Response\TuneResponseV1;
+use CrazyGoat\RabbitStream\StreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class ReadMessageTimeoutTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    public static function setUpBeforeClass(): void
+    {
+        $host = getenv('RABBITMQ_HOST') ?: self::$host;
+        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+        self::$host = $host;
+        self::$port = $port;
+    }
+
+    private function createConnection(): StreamConnection
+    {
+        $connection = new StreamConnection(self::$host, self::$port);
+        $connection->connect();
+        return $connection;
+    }
+
+    private function performHandshake(StreamConnection $connection): void
+    {
+        $connection->sendMessage(new PeerPropertiesRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslHandshakeRequestV1());
+        $connection->readMessage();
+
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $connection->readMessage();
+
+        $tune = $connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+        $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        $connection->sendMessage(new OpenRequestV1('/'));
+        $connection->readMessage();
+    }
+
+    public function testReadMessageTimesOutWhenNoDataAvailable(): void
+    {
+        $connection = $this->createConnection();
+        $this->performHandshake($connection);
+
+        // Don't send any request — readMessage should block and eventually timeout
+        $start = microtime(true);
+
+        try {
+            $connection->readMessage(timeout: 1.0);
+            $this->fail('Expected TimeoutException to be thrown');
+        } catch (TimeoutException $e) {
+            $this->assertStringContainsString('Read timeout', $e->getMessage());
+        }
+
+        $elapsed = microtime(true) - $start;
+        $this->assertGreaterThan(0.9, $elapsed);
+        $this->assertLessThan(2.0, $elapsed);
+
+        $connection->close();
+    }
+
+    public function testConnectionRemainsUsableAfterTimeout(): void
+    {
+        $connection = $this->createConnection();
+        $this->performHandshake($connection);
+
+        // First read should timeout (no pending data)
+        try {
+            $connection->readMessage(timeout: 0.5);
+            $this->fail('Expected TimeoutException to be thrown');
+        } catch (TimeoutException $e) {
+            $this->assertStringContainsString('Read timeout', $e->getMessage());
+        }
+
+        // Now send a proper request and verify we get a response
+        $connection->sendMessage(new CloseRequestV1());
+        $response = $connection->readMessage();
+
+        $this->assertInstanceOf(CloseResponseV1::class, $response);
+
+        $connection->close();
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testReadMessageWithZeroTimeoutReturnsImmediately(): void
+    {
+        $connection = $this->createConnection();
+        $this->performHandshake($connection);
+
+        $start = microtime(true);
+
+        try {
+            $connection->readMessage(timeout: 0.0);
+            $this->fail('Expected TimeoutException to be thrown');
+        } catch (TimeoutException $e) {
+            $this->assertStringContainsString('Read timeout', $e->getMessage());
+        }
+
+        $elapsed = microtime(true) - $start;
+        // With timeout 0.0, readFrame does a non-blocking poll and returns immediately
+        $this->assertLessThan(0.5, $elapsed);
+
+        $connection->close();
+    }
+}


### PR DESCRIPTION
## Summary

Adds E2E tests for `readMessage()` timeout behavior in `StreamConnection`.

### Tests added

1. **testReadMessageTimesOutWhenNoDataAvailable** — verifies that `readMessage(timeout: 1.0)` throws `TimeoutException` after approximately 1 second when no data is available on the connection.

2. **testConnectionRemainsUsableAfterTimeout** — verifies that after a timeout, the connection is still usable and can send/receive requests normally.

3. **testReadMessageWithZeroTimeoutReturnsImmediately** — verifies that `readMessage(timeout: 0.0)` returns immediately (within 0.5s) as it does a non-blocking poll.

### Acceptance criteria

- [x] Timeout of N seconds causes exception after approximately N seconds
- [x] Exception is `TimeoutException` with message "Read timeout"
- [x] Connection remains usable after timeout (not corrupted)
- [x] Zero timeout returns immediately