### PR TITLE
E2E test: Super stream publish and consume through partitions

### DIFF
--- a/src/Client/Connection.php
+++ b/src/Client/Connection.php
@@ -12,11 +12,14 @@ use CrazyGoat\RabbitStream\Exception\AuthenticationException;
 use CrazyGoat\RabbitStream\Exception\UnexpectedResponseException;
 use CrazyGoat\RabbitStream\Request\CloseRequestV1;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
+use CrazyGoat\RabbitStream\Request\CreateSuperStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\DeleteStreamRequestV1;
+use CrazyGoat\RabbitStream\Request\DeleteSuperStreamRequestV1;
 use CrazyGoat\RabbitStream\Request\MetadataRequestV1;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\QueryOffsetRequestV1;
+use CrazyGoat\RabbitStream\Request\RouteRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
 use CrazyGoat\RabbitStream\Request\StoreOffsetRequestV1;
@@ -24,11 +27,14 @@ use CrazyGoat\RabbitStream\Request\StreamStatsRequestV1;
 use CrazyGoat\RabbitStream\Request\TuneRequestV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\CreateResponseV1;
+use CrazyGoat\RabbitStream\Response\CreateSuperStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\DeleteStreamResponseV1;
+use CrazyGoat\RabbitStream\Response\DeleteSuperStreamResponseV1;
 use CrazyGoat\RabbitStream\Response\MetadataResponseV1;
 use CrazyGoat\RabbitStream\Response\OpenResponseV1;
 use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
 use CrazyGoat\RabbitStream\Response\QueryOffsetResponseV1;
+use CrazyGoat\RabbitStream\Response\RouteResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\Response\StreamStatsResponseV1;
@@ -167,6 +173,49 @@ class Connection implements ConnectionInterface
         if (!$response instanceof DeleteStreamResponseV1) {
             throw UnexpectedResponseException::create(DeleteStreamResponseV1::class, $response);
         }
+    }
+
+    /**
+     * @param string[] $partitions
+     * @param string[] $bindingKeys
+     * @param array<string, string> $arguments
+     */
+    public function createSuperStream(
+        string $name,
+        array $partitions = [],
+        array $bindingKeys = [],
+        array $arguments = []
+    ): void {
+        $this->streamConnection->sendMessage(new CreateSuperStreamRequestV1(
+            $name,
+            $partitions,
+            $bindingKeys,
+            $arguments
+        ));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof CreateSuperStreamResponseV1) {
+            throw UnexpectedResponseException::create(CreateSuperStreamResponseV1::class, $response);
+        }
+    }
+
+    public function deleteSuperStream(string $name): void
+    {
+        $this->streamConnection->sendMessage(new DeleteSuperStreamRequestV1($name));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof DeleteSuperStreamResponseV1) {
+            throw UnexpectedResponseException::create(DeleteSuperStreamResponseV1::class, $response);
+        }
+    }
+
+    /** @return string[] */
+    public function route(string $routingKey, string $superStream): array
+    {
+        $this->streamConnection->sendMessage(new RouteRequestV1($routingKey, $superStream));
+        $response = $this->streamConnection->readMessage();
+        if (!$response instanceof RouteResponseV1) {
+            throw UnexpectedResponseException::create(RouteResponseV1::class, $response);
+        }
+        return $response->getStreams();
     }
 
     public function streamExists(string $name): bool

--- a/src/Contract/ConnectionInterface.php
+++ b/src/Contract/ConnectionInterface.php
@@ -14,6 +14,23 @@ interface ConnectionInterface
 
     public function deleteStream(string $name): void;
 
+    /**
+     * @param string[] $partitions
+     * @param string[] $bindingKeys
+     * @param array<string, string> $arguments
+     */
+    public function createSuperStream(
+        string $name,
+        array $partitions = [],
+        array $bindingKeys = [],
+        array $arguments = []
+    ): void;
+
+    public function deleteSuperStream(string $name): void;
+
+    /** @return string[] */
+    public function route(string $routingKey, string $superStream): array;
+
     public function streamExists(string $name): bool;
 
     /** @return array<string, int> */

--- a/tests/E2E/SuperStreamPublishConsumeTest.php
+++ b/tests/E2E/SuperStreamPublishConsumeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Client\Message;
+use CrazyGoat\RabbitStream\VO\OffsetSpec;
+use PHPUnit\Framework\TestCase;
+
+class SuperStreamPublishConsumeTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+
+    private ?Connection $connection = null;
+    private string $superStreamName = '';
+
+    private function amqp(string $body): string
+    {
+        return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+    }
+
+    protected function setUp(): void
+    {
+        $this->connection = Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: 'guest',
+            password: 'guest',
+            vhost: '/'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->connection instanceof Connection) {
+            try {
+                if ($this->superStreamName !== '') {
+                    $this->connection->deleteSuperStream($this->superStreamName);
+                }
+            } catch (\Exception) {
+                // Ignore cleanup errors
+            }
+            $this->connection->close();
+        }
+    }
+
+    public function testSuperStreamPublishAndConsume(): void
+    {
+        $this->assertNotNull($this->connection);
+
+        $this->superStreamName = 'test-super-pub-' . uniqid();
+        $partitions = [
+            $this->superStreamName . '-0',
+            $this->superStreamName . '-1',
+            $this->superStreamName . '-2',
+        ];
+
+        // Create super stream with 3 partitions and binding keys
+        $this->connection->createSuperStream(
+            $this->superStreamName,
+            $partitions,
+            ['0', '1', '2']
+        );
+
+        // Query route for key '1' — should return partition-1
+        $route = $this->connection->route('1', $this->superStreamName);
+        $this->assertNotEmpty($route);
+        $targetPartition = $route[0];
+        $this->assertSame($this->superStreamName . '-1', $targetPartition);
+
+        // Publish a message to the target partition
+        $producer = $this->connection->createProducer($targetPartition);
+        $producer->send($this->amqp('super-stream-message'));
+        $producer->waitForConfirms(timeout: 5.0);
+        $producer->close();
+
+        // Consume from the target partition
+        $consumer = $this->connection->createConsumer($targetPartition, OffsetSpec::first());
+
+        $received = [];
+        $deadline = time() + 5;
+        while (count($received) < 1 && time() < $deadline) {
+            $messages = $consumer->read(timeout: 0.5);
+            foreach ($messages as $msg) {
+                $received[] = $msg;
+            }
+        }
+
+        $consumer->close();
+
+        $this->assertCount(1, $received);
+        $this->assertInstanceOf(Message::class, $received[0]);
+        $this->assertSame('super-stream-message', $received[0]->getBody());
+    }
+}


### PR DESCRIPTION
Closes #175

## Summary

Adds E2E test verifying the complete super stream workflow:
1. Create super stream with partitions and binding keys
2. Route query returns correct partition for routing key
3. Publish message to partition with confirmation
4. Consume message from partition and verify body

## Changes

- `src/Client/Connection.php`: Added `createSuperStream()`, `deleteSuperStream()`, `route()` methods
- `src/Contract/ConnectionInterface.php`: Added interface declarations for new methods
- `tests/E2E/SuperStreamPublishConsumeTest.php`: New E2E test

## QA

- [x] Unit tests pass (616/616)
- [x] Lint passes (PSR-12)
- [x] Code review passed