### PR TITLE
test: E2E test for server-initiated close handling (closes #151)

### DIFF
--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -524,12 +524,17 @@ class StreamConnection
 
         while ($remaining > 0) {
             $chunk = socket_read($this->socket, $remaining);
-            if ($chunk === false || $chunk === '') {
+            if ($chunk === false) {
                 $error = socket_last_error($this->socket);
                 if ($error === SOCKET_ETIMEDOUT) {
                     return null;
                 }
+                $this->connected = false;
                 throw new ConnectionException("Failed to read from socket: " . socket_strerror($error));
+            }
+            if ($chunk === '') {
+                $this->connected = false;
+                throw new ConnectionException("Failed to read from socket: connection closed by peer");
             }
 
             $data .= $chunk;

--- a/tests/E2E/ServerInitiatedCloseTest.php
+++ b/tests/E2E/ServerInitiatedCloseTest.php
@@ -83,7 +83,10 @@ class ServerInitiatedCloseTest extends TestCase
             }
         }
 
-        $this->assertNotNull($lastException, 'Expected ConnectionException was not thrown after server-initiated close');
+        $this->assertNotNull(
+            $lastException,
+            'Expected ConnectionException was not thrown after server-initiated close'
+        );
 
         // After the operation fails, connection should be marked as disconnected
         $this->assertFalse($connection->isConnected());

--- a/tests/E2E/ServerInitiatedCloseTest.php
+++ b/tests/E2E/ServerInitiatedCloseTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Exception\ConnectionException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group destructive
+ */
+class ServerInitiatedCloseTest extends TestCase
+{
+    private static string $host = '127.0.0.1';
+    private static int $port = 5552;
+    private static int $managementPort = 15672;
+
+    private ?Connection $connection = null;
+    private string $streamName;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
+        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+        self::$managementPort = (int)(getenv('RABBITMQ_MANAGEMENT_PORT') ?: self::$managementPort);
+    }
+
+    protected function setUp(): void
+    {
+        $this->connection = Connection::create(self::$host, self::$port);
+        $this->streamName = 'test-srv-close-' . uniqid();
+        $this->connection->createStream($this->streamName);
+    }
+
+    protected function tearDown(): void
+    {
+        // Try to clean up the stream via a new connection if our connection was closed
+        try {
+            $cleanupConn = Connection::create(self::$host, self::$port);
+            $cleanupConn->deleteStream($this->streamName);
+            $cleanupConn->close();
+        } catch (\Exception) {
+            // Ignore cleanup errors
+        }
+
+        if ($this->connection instanceof Connection) {
+            try {
+                $this->connection->close();
+            } catch (\Exception) {
+                // Ignore cleanup errors - connection may already be closed
+            }
+        }
+    }
+
+    public function testServerInitiatedCloseIsHandledGracefully(): void
+    {
+        $connection = $this->connection;
+        $this->assertNotNull($connection);
+
+        // Find our connection name in RabbitMQ management API
+        // The management API may need a few seconds to register the connection
+        $connectionName = $this->getStreamConnectionName();
+        $this->assertNotNull($connectionName, 'Could not find stream connection in management API');
+
+        // Force-close the connection via management API
+        $this->forceCloseConnection($connectionName);
+
+        // The server needs a moment to close the TCP connection.
+        // Retry createStream until it throws ConnectionException.
+        $maxAttempts = 10;
+        $lastException = null;
+
+        for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+            try {
+                $connection->createStream('another-stream-' . uniqid());
+                // Still connected - wait and retry
+                usleep(200_000);
+            } catch (ConnectionException $e) {
+                $lastException = $e;
+                break;
+            }
+        }
+
+        $this->assertNotNull($lastException, 'Expected ConnectionException was not thrown after server-initiated close');
+
+        // After the operation fails, connection should be marked as disconnected
+        $this->assertFalse($connection->isConnected());
+    }
+
+    private function getStreamConnectionName(): ?string
+    {
+        $maxWait = 10;
+        $start = time();
+
+        while (time() - $start < $maxWait) {
+            $data = $this->curlGet(
+                sprintf('http://%s:%d/api/connections', self::$host, self::$managementPort)
+            );
+
+            if ($data === null) {
+                sleep(1);
+                continue;
+            }
+
+            $connections = json_decode($data, true);
+            if (!is_array($connections)) {
+                sleep(1);
+                continue;
+            }
+
+            foreach ($connections as $conn) {
+                if (!is_array($conn)) {
+                    continue;
+                }
+                if (!isset($conn['port'])) {
+                    continue;
+                }
+                if ($conn['port'] !== self::$port) {
+                    continue;
+                }
+                if (!isset($conn['protocol'])) {
+                    continue;
+                }
+                if ($conn['protocol'] !== 'stream') {
+                    continue;
+                }
+                if (!isset($conn['name'])) {
+                    continue;
+                }
+                if (!is_string($conn['name'])) {
+                    continue;
+                }
+
+                return $conn['name'];
+            }
+
+            sleep(1);
+        }
+
+        return null;
+    }
+
+    private function forceCloseConnection(string $name): void
+    {
+        $url = sprintf(
+            'http://%s:%d/api/connections/%s',
+            self::$host,
+            self::$managementPort,
+            rawurlencode($name)
+        );
+
+        $this->curlDelete($url);
+    }
+
+    private function curlGet(string $url): ?string
+    {
+        $cmd = sprintf(
+            'curl -sf -u guest:guest %s 2>/dev/null',
+            escapeshellarg($url)
+        );
+
+        $output = [];
+        $returnCode = 0;
+        exec($cmd, $output, $returnCode);
+
+        if ($returnCode !== 0 || $output === []) {
+            return null;
+        }
+
+        return implode("\n", $output);
+    }
+
+    private function curlDelete(string $url): void
+    {
+        $cmd = sprintf(
+            'curl -sf -u guest:guest -X DELETE %s >/dev/null 2>/dev/null',
+            escapeshellarg($url)
+        );
+
+        exec($cmd);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #151

## Changes

- Add `tests/E2E/ServerInitiatedCloseTest.php` — E2E test that force-closes a connection via RabbitMQ management API and verifies operations throw `ConnectionException` and `isConnected()` returns false
- Fix `src/StreamConnection.php:readBytes()` — set `$this->connected = false` on socket read errors (matching the pattern already used in `sendFrame()`), and handle empty string EOF separately

## Reference implementations checked

- [x] Go client: rabbitmq/rabbitmq-stream-go-client
- [x] Java client: rabbitmq/rabbitmq-stream-java-client
- [x] Rust client: rabbitmq/rabbitmq-stream-rust-client
- [x] Python client: qweeze/rstream
- [x] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec — not applicable

## Testing

- Unit tests: 616 pass (all)
- E2E test: ServerInitiatedCloseTest passes against real RabbitMQ
- Lint (PHPCS): pass
- PHPStan: pass (no new errors)
- Rector: pass