### PR TITLE
test: E2E test for operations after connection close should throw (closes #150)

### DIFF
--- a/tests/E2E/OperationsAfterCloseTest.php
+++ b/tests/E2E/OperationsAfterCloseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\RabbitStream\Tests\E2E;
+
+use CrazyGoat\RabbitStream\Client\Connection;
+use CrazyGoat\RabbitStream\Exception\ConnectionException;
+use CrazyGoat\RabbitStream\Request\CloseRequestV1;
+
+class OperationsAfterCloseTest extends E2ETestCase
+{
+    public function testSendMessageAfterCloseThrows(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+        $connection->sendMessage(new CloseRequestV1());
+    }
+
+    public function testReadMessageAfterCloseThrows(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Connection closed');
+        $connection->readMessage();
+    }
+
+    public function testHighLevelMethodsAfterCloseThrow(): void
+    {
+        $connection = Connection::create(self::$host, self::$port);
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $connection->createStream('should-fail-' . uniqid());
+    }
+
+    public function testDoubleCloseIsIdempotent(): void
+    {
+        $connection = Connection::create(self::$host, self::$port);
+
+        $connection->close();
+        $this->assertFalse($connection->isConnected());
+
+        $connection->close();
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testIsConnectedFalseAfterClose(): void
+    {
+        $connection = $this->connectAndOpen();
+
+        $connection->close();
+
+        $this->assertFalse($connection->isConnected());
+    }
+}


### PR DESCRIPTION
Implements E2E tests for issue #150 - verifying that operations after connection close properly throw ConnectionException.

## Changes

New test file `tests/E2E/OperationsAfterCloseTest.php` with 5 tests:

- **testSendMessageAfterCloseThrows** - `StreamConnection::sendMessage()` after `close()` throws `ConnectionException`
- **testReadMessageAfterCloseThrows** - `StreamConnection::readMessage()` after `close()` throws `ConnectionException`
- **testHighLevelMethodsAfterCloseThrow** - `Connection::createStream()` after `close()` throws `ConnectionException`
- **testDoubleCloseIsIdempotent** - Calling `Connection::close()` twice does not throw
- **testIsConnectedFalseAfterClose** - `isConnected()` returns `false` after `close()`