### PR TITLE
test: add E2E test for invalid vhost rejection (closes #149)

### DIFF
--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -146,4 +146,28 @@ class ConnectionHandshakeTest extends TestCase
             $this->assertStringContainsString('Read timeout', $e->getMessage());
         }
     }
+
+    public function testInvalidVhostThrows(): void
+    {
+        $this->connection = $this->createConnection();
+
+        $this->connection->sendMessage(new PeerPropertiesRequestV1());
+        $this->connection->readMessage();
+
+        $this->connection->sendMessage(new SaslHandshakeRequestV1());
+        $this->connection->readMessage();
+
+        $this->connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $this->connection->readMessage();
+
+        $tune = $this->connection->readMessage();
+        $this->assertInstanceOf(TuneRequestV1::class, $tune);
+        $this->connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
+
+        $this->connection->sendMessage(new OpenRequestV1('/nonexistent-vhost'));
+
+        $this->expectException(ProtocolException::class);
+        $this->expectExceptionMessage('VIRTUAL_HOST_ACCESS_FAILURE');
+        $this->connection->readMessage();
+    }
 }


### PR DESCRIPTION
## Summary

Adds E2E test verifying that the client correctly rejects connections to a non-existent virtual host.

## Changes

- `tests/E2E/ConnectionHandshakeTest.php:testInvalidVhostThrows()` — completes handshake, sends `OpenRequestV1('/nonexistent-vhost')`, expects `ProtocolException` with `VIRTUAL_HOST_ACCESS_FAILURE`

## Acceptance criteria

- [x] Test with non-existent vhost → exception with `VIRTUAL_HOST_ACCESS_FAILURE`

Closes #149