### PR TITLE
perf: reduce E2E test timeouts (#343, #344, #345)

### DIFF
--- a/tests/E2E/ConsumerTest.php
+++ b/tests/E2E/ConsumerTest.php
@@ -392,8 +392,8 @@ class ConsumerTest extends TestCase
         $producer->waitForConfirms(timeout: 5);
         $producer->close();
 
-        $timestamp = time() * 1000;
-        sleep(1);
+        $timestamp = (int)(microtime(true) * 1000);
+        usleep(100_000);
 
         $producer2 = $this->connection->createProducer($this->streamName);
         for ($i = 0; $i < 5; $i++) {

--- a/tests/E2E/CreditFlowControlTest.php
+++ b/tests/E2E/CreditFlowControlTest.php
@@ -110,7 +110,7 @@ class CreditFlowControlTest extends E2ETestCase
             $this->assertSame(20, $pubConfirmCount, 'All 20 published messages should be confirmed');
 
             // readLoop with short timeout on sub — no credit, no deliveries
-            $subConnection->readLoop(timeout: 1.0);
+            $subConnection->readLoop(timeout: 0.2);
             $this->assertSame(1, $deliverCount, 'No new deliveries without credit');
 
             // Send more credit on subConnection

--- a/tests/E2E/ReadLoopTimeoutTest.php
+++ b/tests/E2E/ReadLoopTimeoutTest.php
@@ -62,11 +62,11 @@ class ReadLoopTimeoutTest extends E2ETestCase
         $this->connection = $connection;
 
         $start = microtime(true);
-        $connection->readLoop(timeout: 1.0);
+        $connection->readLoop(timeout: 0.3);
         $elapsed = microtime(true) - $start;
 
-        $this->assertGreaterThan(0.8, $elapsed, 'readLoop should block for approximately the timeout duration');
-        $this->assertLessThan(2.0, $elapsed, 'readLoop should not block significantly longer than the timeout');
+        $this->assertGreaterThan(0.2, $elapsed, 'readLoop should block for approximately the timeout duration');
+        $this->assertLessThan(1.0, $elapsed, 'readLoop should not block significantly longer than the timeout');
     }
 
     public function testReadLoopWithZeroTimeout(): void

--- a/tests/E2E/ReadMessageTimeoutTest.php
+++ b/tests/E2E/ReadMessageTimeoutTest.php
@@ -18,15 +18,15 @@ class ReadMessageTimeoutTest extends E2ETestCase
         $start = microtime(true);
 
         try {
-            $connection->readMessage(timeout: 1.0);
+            $connection->readMessage(timeout: 0.3);
             $this->fail('Expected TimeoutException to be thrown');
         } catch (TimeoutException $e) {
             $this->assertStringContainsString('Read timeout', $e->getMessage());
         }
 
         $elapsed = microtime(true) - $start;
-        $this->assertGreaterThan(0.9, $elapsed);
-        $this->assertLessThan(2.0, $elapsed);
+        $this->assertGreaterThan(0.2, $elapsed);
+        $this->assertLessThan(1.0, $elapsed);
 
         $connection->close();
     }


### PR DESCRIPTION
## Summary

Reduces unnecessary wait times in E2E tests to speed up the suite.

### Changes

- **#343 (ConsumerTest)**: `sleep(1)` → `usleep(100_000)` (100ms) for timestamp gap in `testSubscribeFromTimestamp`
- **#344 (CreditFlowControlTest)**: `readLoop(timeout: 1.0)` → `0.2` for no-credit assertion  
- **#345 (ReadMessageTimeoutTest)**: `readMessage(timeout: 1.0)` → `0.3`, adjusted assertion bounds
- **#345 (ReadLoopTimeoutTest)**: `readLoop(timeout: 1.0)` → `0.3`, adjusted assertion bounds

**Total estimated savings: ~3.1s per E2E run.**

Closes #343, #344, #345