### PR TITLE
E2E: 18 test classes extend E2ETestCase instead of TestCase (closes #346)

### DIFF
--- a/tests/E2E/CloseTest.php
+++ b/tests/E2E/CloseTest.php
@@ -13,22 +13,10 @@ use CrazyGoat\RabbitStream\Request\TuneRequestV1;
 use CrazyGoat\RabbitStream\Response\CloseResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\TestCase;
 
-class CloseTest extends TestCase
+class CloseTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        $host = getenv('RABBITMQ_HOST') ?: self::$host;
-        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-        self::$host = $host;
-        self::$port = $port;
-    }
-
-    private function createConnection(): StreamConnection
+    private function createRawConnection(): StreamConnection
     {
         $connection = new StreamConnection(self::$host, self::$port);
         $connection->connect();
@@ -56,7 +44,7 @@ class CloseTest extends TestCase
 
     public function testCloseCommand(): void
     {
-        $connection = $this->createConnection();
+        $connection = $this->createRawConnection();
         $this->performHandshake($connection);
 
         $connection->sendMessage(new CloseRequestV1());

--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -18,21 +18,10 @@ use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
 use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\TestCase;
 
-class ConnectionHandshakeTest extends TestCase
+class ConnectionHandshakeTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
     private ?StreamConnection $connection = null;
-
-    public static function setUpBeforeClass(): void
-    {
-        $host = getenv('RABBITMQ_HOST') ?: self::$host;
-        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-        self::$host = $host;
-        self::$port = $port;
-    }
 
     protected function tearDown(): void
     {
@@ -50,7 +39,7 @@ class ConnectionHandshakeTest extends TestCase
         $this->connection = null;
     }
 
-    private function createConnection(): StreamConnection
+    private function createRawConnection(): StreamConnection
     {
         $connection = new StreamConnection(self::$host, self::$port);
         $connection->connect();
@@ -59,7 +48,7 @@ class ConnectionHandshakeTest extends TestCase
 
     public function testPeerPropertiesExchange(): StreamConnection
     {
-        $this->connection = $this->createConnection();
+        $this->connection = $this->createRawConnection();
 
         $this->connection->sendMessage(new PeerPropertiesRequestV1());
         $response = $this->connection->readMessage();
@@ -97,7 +86,7 @@ class ConnectionHandshakeTest extends TestCase
 
     public function testFullHandshake(): void
     {
-        $connection = $this->createConnection();
+        $connection = $this->createRawConnection();
 
         $connection->sendMessage(new PeerPropertiesRequestV1());
         $peerResponse = $connection->readMessage();
@@ -127,7 +116,7 @@ class ConnectionHandshakeTest extends TestCase
 
     public function testInvalidCredentialsThrows(): void
     {
-        $this->connection = $this->createConnection();
+        $this->connection = $this->createRawConnection();
 
         $this->connection->sendMessage(new PeerPropertiesRequestV1());
         $this->connection->readMessage();
@@ -149,7 +138,7 @@ class ConnectionHandshakeTest extends TestCase
 
     public function testInvalidVhostThrows(): void
     {
-        $this->connection = $this->createConnection();
+        $this->connection = $this->createRawConnection();
 
         $this->connection->sendMessage(new PeerPropertiesRequestV1());
         $this->connection->readMessage();

--- a/tests/E2E/ConnectionResilienceTest.php
+++ b/tests/E2E/ConnectionResilienceTest.php
@@ -7,32 +7,16 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Exception\ConnectionException;
 use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @group destructive
  * @group slow
  */
-class ConnectionResilienceTest extends TestCase
+class ConnectionResilienceTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     public function testOperationAfterSocketDisconnect(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-resilience-' . uniqid();
         $connection->createStream($streamName);
@@ -47,13 +31,7 @@ class ConnectionResilienceTest extends TestCase
 
     public function testIsConnectedReturnsFalseAfterSocketError(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $this->assertTrue($connection->isConnected());
 
@@ -66,13 +44,7 @@ class ConnectionResilienceTest extends TestCase
 
     public function testNoResourceLeaksAfterSocketError(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-resilience-leak-' . uniqid();
         $connection->createStream($streamName);

--- a/tests/E2E/ConnectionTest.php
+++ b/tests/E2E/ConnectionTest.php
@@ -4,30 +4,13 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Enum\ResponseCodeEnum;
-use PHPUnit\Framework\TestCase;
 
-class ConnectionTest extends TestCase
+class ConnectionTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     public function testConnectionCreateAndStreamManagement(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-connection-stream-' . uniqid();
 
@@ -49,13 +32,7 @@ class ConnectionTest extends TestCase
 
     public function testCreateStreamWithArguments(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-connection-stream-args-' . uniqid();
 
@@ -75,13 +52,7 @@ class ConnectionTest extends TestCase
 
     public function testGetMetadata(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-metadata-stream-' . uniqid();
         $connection->createStream($streamName);
@@ -98,13 +69,7 @@ class ConnectionTest extends TestCase
 
     public function testMetadataForMultipleStreams(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $existing1 = 'test-meta-multi-1-' . uniqid();
         $existing2 = 'test-meta-multi-2-' . uniqid();
@@ -143,13 +108,7 @@ class ConnectionTest extends TestCase
 
     public function testGetStreamStats(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-stats-stream-' . uniqid();
         $connection->createStream($streamName);
@@ -165,13 +124,7 @@ class ConnectionTest extends TestCase
 
     public function testCreateDuplicateStreamThrows(): void
     {
-        $connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $connection = $this->createConnection();
 
         $streamName = 'test-duplicate-stream-' . uniqid();
 

--- a/tests/E2E/ConsumerTest.php
+++ b/tests/E2E/ConsumerTest.php
@@ -7,13 +7,9 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class ConsumerTest extends TestCase
+class ConsumerTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
@@ -22,21 +18,9 @@ class ConsumerTest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-consumer-' . uniqid();
         $this->connection->createStream($this->streamName);
     }

--- a/tests/E2E/E2ETestCase.php
+++ b/tests/E2E/E2ETestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
+use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Request\OpenRequestV1;
 use CrazyGoat\RabbitStream\Request\PeerPropertiesRequestV1;
 use CrazyGoat\RabbitStream\Request\SaslAuthenticateRequestV1;
@@ -24,8 +25,25 @@ abstract class E2ETestCase extends TestCase
         self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
     }
 
-    protected function connectAndOpen(): StreamConnection
-    {
+    protected function createConnection(
+        string $user = 'guest',
+        string $password = 'guest',
+        string $vhost = '/'
+    ): Connection {
+        return Connection::create(
+            host: self::$host,
+            port: self::$port,
+            user: $user,
+            password: $password,
+            vhost: $vhost,
+        );
+    }
+
+    protected function connectAndOpen(
+        string $user = 'guest',
+        string $password = 'guest',
+        string $vhost = '/'
+    ): StreamConnection {
         $connection = new StreamConnection(self::$host, self::$port);
         $connection->connect();
 
@@ -35,14 +53,14 @@ abstract class E2ETestCase extends TestCase
         $connection->sendMessage(new SaslHandshakeRequestV1());
         $connection->readMessage();
 
-        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
+        $connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', $user, $password));
         $connection->readMessage();
 
         $tune = $connection->readMessage();
         $this->assertInstanceOf(TuneRequestV1::class, $tune);
         $connection->sendMessage(new TuneResponseV1($tune->getFrameMax(), $tune->getHeartbeat()));
 
-        $connection->sendMessage(new OpenRequestV1('/'));
+        $connection->sendMessage(new OpenRequestV1($vhost));
         $connection->readMessage();
 
         return $connection;

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -21,24 +21,13 @@ use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\TestCase;
 
-class HeartbeatTest extends TestCase
+class HeartbeatTest extends E2ETestCase
 {
     private const HEARTBEAT_INTERVAL = 1;
     private const MARGIN = 2;
 
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
     private ?StreamConnection $connection = null;
-
-    public static function setUpBeforeClass(): void
-    {
-        $host = getenv('RABBITMQ_HOST') ?: self::$host;
-        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-        self::$host = $host;
-        self::$port = $port;
-    }
 
     protected function tearDown(): void
     {

--- a/tests/E2E/LargeMessageE2ETest.php
+++ b/tests/E2E/LargeMessageE2ETest.php
@@ -7,13 +7,9 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class LargeMessageE2ETest extends TestCase
+class LargeMessageE2ETest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
@@ -22,21 +18,9 @@ class LargeMessageE2ETest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-large-msg-' . uniqid();
         $this->connection->createStream($this->streamName);
     }
@@ -98,9 +82,6 @@ class LargeMessageE2ETest extends TestCase
         $conn = Connection::create(
             host: self::$host,
             port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/',
             requestedFrameMax: 4096,
         );
 

--- a/tests/E2E/MessageContentTest.php
+++ b/tests/E2E/MessageContentTest.php
@@ -7,13 +7,9 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class MessageContentTest extends TestCase
+class MessageContentTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
@@ -22,21 +18,9 @@ class MessageContentTest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-msg-content-' . uniqid();
         $this->connection->createStream($this->streamName);
     }

--- a/tests/E2E/MultipleConsumersTest.php
+++ b/tests/E2E/MultipleConsumersTest.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\Contract\ConsumerInterface;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class MultipleConsumersTest extends TestCase
+class MultipleConsumersTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     private function amqp(string $body): string
     {
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
@@ -30,8 +19,8 @@ class MultipleConsumersTest extends TestCase
     {
         $stream = 'test-multi-consumer-' . uniqid();
 
-        $conn1 = Connection::create(self::$host, self::$port);
-        $conn2 = Connection::create(self::$host, self::$port);
+        $conn1 = $this->createConnection();
+        $conn2 = $this->createConnection();
 
         try {
             $conn1->createStream($stream);
@@ -79,7 +68,7 @@ class MultipleConsumersTest extends TestCase
     {
         $stream = 'test-multi-consumer-same-conn-' . uniqid();
 
-        $conn = Connection::create(self::$host, self::$port);
+        $conn = $this->createConnection();
 
         try {
             $conn->createStream($stream);
@@ -132,7 +121,7 @@ class MultipleConsumersTest extends TestCase
         $streamA = 'test-multi-stream-A-' . uniqid();
         $streamB = 'test-multi-stream-B-' . uniqid();
 
-        $conn = Connection::create(self::$host, self::$port);
+        $conn = $this->createConnection();
 
         try {
             $conn->createStream($streamA);
@@ -196,7 +185,7 @@ class MultipleConsumersTest extends TestCase
         $streamA = 'test-unsub-A-' . uniqid();
         $streamB = 'test-unsub-B-' . uniqid();
 
-        $conn = Connection::create(self::$host, self::$port);
+        $conn = $this->createConnection();
 
         try {
             $conn->createStream($streamA);

--- a/tests/E2E/MultiplePublishersTest.php
+++ b/tests/E2E/MultiplePublishersTest.php
@@ -6,27 +6,17 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
-use PHPUnit\Framework\TestCase;
 
-class MultiplePublishersTest extends TestCase
+class MultiplePublishersTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
 
     /** @var string[] */
     private array $streamNames = [];
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(self::$host, self::$port);
+        $this->connection = $this->createConnection();
     }
 
     protected function tearDown(): void

--- a/tests/E2E/NamedProducerDeduplicationTest.php
+++ b/tests/E2E/NamedProducerDeduplicationTest.php
@@ -8,13 +8,9 @@ use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Contract\ProducerInterface;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class NamedProducerDeduplicationTest extends TestCase
+class NamedProducerDeduplicationTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private ?ProducerInterface $producer = null;
     private string $streamName;
@@ -25,23 +21,11 @@ class NamedProducerDeduplicationTest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
         $this->streamName = 'test-dedup-stream-' . uniqid();
         $this->producerRef = 'test-dedup-producer-' . uniqid();
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
         $this->connection->createStream($this->streamName);
     }
 
@@ -105,13 +89,7 @@ class NamedProducerDeduplicationTest extends TestCase
         $this->connection = null;
 
         // Step 4: Create a NEW connection with the same producer reference
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
 
         // Step 5: Create new producer with same reference
         $confirmed = [];

--- a/tests/E2E/OperationsAfterCloseTest.php
+++ b/tests/E2E/OperationsAfterCloseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests\E2E;
 
-use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Exception\ConnectionException;
 use CrazyGoat\RabbitStream\Request\CloseRequestV1;
 
@@ -34,7 +33,7 @@ class OperationsAfterCloseTest extends E2ETestCase
 
     public function testHighLevelMethodsAfterCloseThrow(): void
     {
-        $connection = Connection::create(self::$host, self::$port);
+        $connection = $this->createConnection();
         $connection->close();
 
         $this->expectException(ConnectionException::class);
@@ -43,7 +42,7 @@ class OperationsAfterCloseTest extends E2ETestCase
 
     public function testDoubleCloseIsIdempotent(): void
     {
-        $connection = Connection::create(self::$host, self::$port);
+        $connection = $this->createConnection();
 
         $connection->close();
         $this->assertFalse($connection->isConnected());

--- a/tests/E2E/ProducerConsumerOffsetResumeTest.php
+++ b/tests/E2E/ProducerConsumerOffsetResumeTest.php
@@ -7,13 +7,9 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class ProducerConsumerOffsetResumeTest extends TestCase
+class ProducerConsumerOffsetResumeTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
@@ -22,21 +18,9 @@ class ProducerConsumerOffsetResumeTest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-producer-consumer-offset-' . uniqid();
         $this->connection->createStream($this->streamName);
     }

--- a/tests/E2E/ProducerTest.php
+++ b/tests/E2E/ProducerTest.php
@@ -7,25 +7,15 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Exception\TimeoutException;
-use PHPUnit\Framework\TestCase;
 
-class ProducerTest extends TestCase
+class ProducerTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(self::$host, self::$port);
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-producer-' . uniqid();
         $this->connection->createStream($this->streamName);
     }

--- a/tests/E2E/PublishErrorTest.php
+++ b/tests/E2E/PublishErrorTest.php
@@ -6,25 +6,15 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
-use PHPUnit\Framework\TestCase;
 
-class PublishErrorTest extends TestCase
+class PublishErrorTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $streamName;
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(self::$host, self::$port);
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-publish-error-' . uniqid();
         $this->connection->createStream($this->streamName);
     }

--- a/tests/E2E/PublishTest.php
+++ b/tests/E2E/PublishTest.php
@@ -6,28 +6,12 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Client\ConfirmationStatus;
 use CrazyGoat\RabbitStream\Client\Connection;
-use PHPUnit\Framework\TestCase;
 
-class PublishTest extends TestCase
+class PublishTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     private function connect(): Connection
     {
-        return Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        return $this->createConnection();
     }
 
     public function testPublishSingleMessage(): void

--- a/tests/E2E/SaslMechanismValidationTest.php
+++ b/tests/E2E/SaslMechanismValidationTest.php
@@ -12,21 +12,10 @@ use CrazyGoat\RabbitStream\Request\SaslHandshakeRequestV1;
 use CrazyGoat\RabbitStream\Response\PeerPropertiesResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\TestCase;
 
-class SaslMechanismValidationTest extends TestCase
+class SaslMechanismValidationTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
     private ?StreamConnection $connection = null;
-
-    public static function setUpBeforeClass(): void
-    {
-        $host = getenv('RABBITMQ_HOST') ?: self::$host;
-        $port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-        self::$host = $host;
-        self::$port = $port;
-    }
 
     protected function tearDown(): void
     {
@@ -36,7 +25,7 @@ class SaslMechanismValidationTest extends TestCase
         $this->connection = null;
     }
 
-    private function createConnection(): StreamConnection
+    private function createRawConnection(): StreamConnection
     {
         $connection = new StreamConnection(self::$host, self::$port);
         $connection->connect();
@@ -45,7 +34,7 @@ class SaslMechanismValidationTest extends TestCase
 
     private function performHandshakeUpToSaslAuthenticate(): StreamConnection
     {
-        $connection = $this->createConnection();
+        $connection = $this->createRawConnection();
 
         $connection->sendMessage(new PeerPropertiesRequestV1());
         $response = $connection->readMessage();

--- a/tests/E2E/ServerInitiatedCloseTest.php
+++ b/tests/E2E/ServerInitiatedCloseTest.php
@@ -6,15 +6,12 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Exception\ConnectionException;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @group destructive
  */
-class ServerInitiatedCloseTest extends TestCase
+class ServerInitiatedCloseTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
     private static int $managementPort = 15672;
 
     private ?Connection $connection = null;
@@ -22,14 +19,13 @@ class ServerInitiatedCloseTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
+        parent::setUpBeforeClass();
         self::$managementPort = (int)(getenv('RABBITMQ_MANAGEMENT_PORT') ?: self::$managementPort);
     }
 
     protected function setUp(): void
     {
-        $this->connection = Connection::create(self::$host, self::$port);
+        $this->connection = $this->createConnection();
         $this->streamName = 'test-srv-close-' . uniqid();
         $this->connection->createStream($this->streamName);
     }
@@ -38,7 +34,7 @@ class ServerInitiatedCloseTest extends TestCase
     {
         // Try to clean up the stream via a new connection if our connection was closed
         try {
-            $cleanupConn = Connection::create(self::$host, self::$port);
+            $cleanupConn = $this->createConnection();
             $cleanupConn->deleteStream($this->streamName);
             $cleanupConn->close();
         } catch (\Exception) {

--- a/tests/E2E/SuperStreamPublishConsumeTest.php
+++ b/tests/E2E/SuperStreamPublishConsumeTest.php
@@ -7,13 +7,9 @@ namespace CrazyGoat\RabbitStream\Tests\E2E;
 use CrazyGoat\RabbitStream\Client\Connection;
 use CrazyGoat\RabbitStream\Client\Message;
 use CrazyGoat\RabbitStream\VO\OffsetSpec;
-use PHPUnit\Framework\TestCase;
 
-class SuperStreamPublishConsumeTest extends TestCase
+class SuperStreamPublishConsumeTest extends E2ETestCase
 {
-    private static string $host = '127.0.0.1';
-    private static int $port = 5552;
-
     private ?Connection $connection = null;
     private string $superStreamName = '';
 
@@ -22,21 +18,9 @@ class SuperStreamPublishConsumeTest extends TestCase
         return "\x00\x53\x75\xb0" . pack('N', strlen($body)) . $body;
     }
 
-    public static function setUpBeforeClass(): void
-    {
-        self::$host = getenv('RABBITMQ_HOST') ?: self::$host;
-        self::$port = (int)(getenv('RABBITMQ_PORT') ?: self::$port);
-    }
-
     protected function setUp(): void
     {
-        $this->connection = Connection::create(
-            host: self::$host,
-            port: self::$port,
-            user: 'guest',
-            password: 'guest',
-            vhost: '/'
-        );
+        $this->connection = $this->createConnection();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary

Refactors 19 E2E test classes to extend `E2ETestCase` instead of duplicating `$host`, `$port`, and `setUpBeforeClass()` boilerplate.

### Changes

- **E2ETestCase**: Added `createConnection()` helper (returns `Connection`) and extended `connectAndOpen()` with optional `$user`, `$password`, `$vhost` parameters
- **19 test classes**: Changed `extends TestCase` → `extends E2ETestCase`, removed 54+ lines of duplicated host/port/setup boilerplate
- Replaced `Connection::create(host: ..., port: ..., ...)` calls with `$this->createConnection()`

### Stats

- **20 files changed**, **79 insertions**, **348 deletions**
- All 616 unit tests pass, lint clean

Closes #346