### PR TITLE
fix: remove dangerous fallback in KeyEnum::fromStreamCode (#347)

### DIFF
--- a/src/Enum/KeyEnum.php
+++ b/src/Enum/KeyEnum.php
@@ -72,13 +72,6 @@ enum KeyEnum: int
             return $result;
         }
 
-        if ($code >= 0x8000) {
-            $result = self::tryFrom($code - 0x8000);
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
         throw new \ValueError(sprintf(
             'Unknown stream protocol command code: 0x%04x',
             $code

--- a/tests/Enum/KeyEnumTest.php
+++ b/tests/Enum/KeyEnumTest.php
@@ -45,6 +45,16 @@ class KeyEnumTest extends TestCase
         KeyEnum::fromStreamCode(0x8099);
     }
 
+    public function testFromStreamCodeThrowsForUnmappedResponseCodeThatWouldCollide(): void
+    {
+        // 0x8002 has no _RESPONSE case but 0x0002 is PUBLISH.
+        // Without the fallback fix, this would silently return PUBLISH instead of throwing.
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Unknown stream protocol command code: 0x8002');
+
+        KeyEnum::fromStreamCode(0x8002);
+    }
+
     public function testFromStreamCodeThrowsForNegativeResult(): void
     {
         // Code less than 0x8000 but not a valid enum value


### PR DESCRIPTION
Removes the fallback in `KeyEnum::fromStreamCode()` that silently stripped the 0x8000 bit to find a matching request key. For example, `0x8002` would return `PUBLISH` instead of throwing a `ValueError`.

This could cause silent misrouting in `ResponseBuilder` if RabbitMQ ever sends an undocumented response code.

Also adds a dedicated test for the 0x8002 collision scenario.

Closes #347