### PR TITLE
Fix: null socket in sendFrame, readFrame, readLoop (move check before socket_select)

### DIFF
--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -201,6 +201,10 @@ class StreamConnection
     {
         $this->logger->debug("Socket -> " . bin2hex($frame));
 
+        if (!$this->socket instanceof \Socket) {
+            throw new ConnectionException("Cannot write: socket is not connected");
+        }
+
         // If timeout is specified, wait for socket to be ready for writing
         if ($timeout !== null && $timeout > 0) {
             $deadline = microtime(true) + $timeout;
@@ -228,10 +232,6 @@ class StreamConnection
             if ($ready === 0) {
                 throw new TimeoutException("Write timeout: socket not ready for writing");
             }
-        }
-
-        if (!$this->socket instanceof \Socket) {
-            throw new ConnectionException("Cannot write: socket is not connected");
         }
 
         try {
@@ -291,6 +291,10 @@ class StreamConnection
 
     public function readLoop(?int $maxFrames = null, ?float $timeout = null): void
     {
+        if (!$this->socket instanceof \Socket) {
+            throw new ConnectionException("Cannot read: socket is not connected");
+        }
+
         $this->running = true;
         $dispatched = 0;
         $deadline = $timeout !== null ? microtime(true) + $timeout : null;
@@ -469,6 +473,10 @@ class StreamConnection
 
     public function readFrame(float $timeout = 30.0): ?ReadBuffer
     {
+        if (!$this->socket instanceof \Socket) {
+            throw new ConnectionException("Cannot read: socket is not connected");
+        }
+
         $read = [$this->socket];
         $write = null;
         $except = null;

--- a/tests/StreamConnectionTest.php
+++ b/tests/StreamConnectionTest.php
@@ -739,7 +739,7 @@ class StreamConnectionTest extends TestCase
         $this->expectExceptionMessage('socket is not connected');
 
         $reflection = new \ReflectionMethod($connection, 'readLoop');
-        $reflection->invoke($connection, maxFrames: 1, timeout: 0.1);
+        $reflection->invoke($connection, 1, 0.1);
     }
 
     public function testSendFrameThrowsAfterClose(): void
@@ -786,7 +786,7 @@ class StreamConnectionTest extends TestCase
         $this->expectExceptionMessage('socket is not connected');
 
         $reflection = new \ReflectionMethod($connection, 'readLoop');
-        $reflection->invoke($connection, maxFrames: 1, timeout: 0.1);
+        $reflection->invoke($connection, 1, 0.1);
 
         socket_close($serverSocket);
     }

--- a/tests/StreamConnectionTest.php
+++ b/tests/StreamConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\RabbitStream\Tests;
 
+use CrazyGoat\RabbitStream\Exception\ConnectionException;
 use CrazyGoat\RabbitStream\Request\CreateRequestV1;
 use CrazyGoat\RabbitStream\Request\CreditRequestV1;
 use CrazyGoat\RabbitStream\Request\PublishRequestV1;
@@ -707,5 +708,86 @@ class StreamConnectionTest extends TestCase
         }
 
         return $data;
+    }
+
+    public function testSendFrameThrowsWhenSocketIsNull(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+
+        $connection->sendMessage(new TuneRequestV1(1024, 100));
+    }
+
+    public function testReadFrameThrowsWhenSocketIsNull(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+
+        $reflection = new \ReflectionMethod($connection, 'readFrame');
+        $reflection->invoke($connection);
+    }
+
+    public function testReadLoopThrowsWhenSocketIsNull(): void
+    {
+        $connection = new StreamConnection('127.0.0.1', 5552);
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+
+        $reflection = new \ReflectionMethod($connection, 'readLoop');
+        $reflection->invoke($connection, maxFrames: 1, timeout: 0.1);
+    }
+
+    public function testSendFrameThrowsAfterClose(): void
+    {
+        [$serverSocket, $clientSocket] = $this->createSocketPair();
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        $this->injectSocket($connection, $clientSocket);
+
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+        $connection->sendMessage(new TuneRequestV1(1024, 100));
+
+        socket_close($serverSocket);
+    }
+
+    public function testReadFrameThrowsAfterClose(): void
+    {
+        [$serverSocket, $clientSocket] = $this->createSocketPair();
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        $this->injectSocket($connection, $clientSocket);
+
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+
+        $reflection = new \ReflectionMethod($connection, 'readFrame');
+        $reflection->invoke($connection);
+
+        socket_close($serverSocket);
+    }
+
+    public function testReadLoopThrowsAfterClose(): void
+    {
+        [$serverSocket, $clientSocket] = $this->createSocketPair();
+        $connection = new StreamConnection('127.0.0.1', 5552);
+        $this->injectSocket($connection, $clientSocket);
+
+        $connection->close();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('socket is not connected');
+
+        $reflection = new \ReflectionMethod($connection, 'readLoop');
+        $reflection->invoke($connection, maxFrames: 1, timeout: 0.1);
+
+        socket_close($serverSocket);
     }
 }


### PR DESCRIPTION
## Description

Fixes #349 — moves the socket validity check (`$this->socket instanceof \Socket`) from **after** `socket_select()` to **before** it in `StreamConnection::sendFrame()`. Also applies the same fix to `readFrame()` and `readLoop()` which had the identical bug pattern.

## Changes

- **`src/StreamConnection.php`**: Added null socket guard at the top of `sendFrame()`, `readFrame()`, and `readLoop()` before any `socket_select()` call
- **`tests/StreamConnectionTest.php`**: Added 6 unit tests covering null-socket-throws for all three methods (both on fresh connection and after `close()`)

## Details

The original bug: `sendFrame()` built `$write = [$this->socket]` before checking if the socket was valid. If `close()` was called (setting `$this->socket = null`), `socket_select()` received `[null]`, producing a PHP 8 TypeError instead of a clean `ConnectionException`.

The fix moves the `instanceof \Socket` guard to the top of each method. In single-threaded PHP there is no TOCTOU concern — the check is definitive before any socket API call.

## Testing

- ✅ 622 unit tests pass (616 original + 6 new)
- ✅ PHP_CodeSniffer clean (PSR-12)
- ✅ 6 new tests cover null-socket-throws for sendFrame/readFrame/readLoop