### PR TITLE
perf: replace array_merge with array_push in Consumer::subscribe (#348)

### DIFF
--- a/src/Client/Consumer.php
+++ b/src/Client/Consumer.php
@@ -50,7 +50,7 @@ class Consumer implements ConsumerInterface
             function ($deliverResponse): void {
                 $entries = OsirisChunkParser::parse($deliverResponse->getChunkBytes());
                 $messages = AmqpMessageDecoder::decodeAll($entries);
-                $this->buffer = array_merge($this->buffer, $messages);
+                array_push($this->buffer, ...$messages);
 
                 if (count($this->buffer) < $this->maxBufferSize) {
                     $this->connection->sendMessage(


### PR DESCRIPTION
Fixes #348

Replaces `array_merge($this->buffer, $messages)` with `array_push($this->buffer, ...$messages)` in the hot path of `Consumer::subscribe`.

`array_merge` always allocates a new array and copies all elements. When the buffer is large (e.g. `maxBufferSize = 1000`) and deliveries arrive frequently, this creates significant GC pressure. `array_push` with spread avoids the full copy and is O(n) only for the new elements, not the entire buffer.

### Verification
- [x] Unit tests pass (628 tests, 1362 assertions)
- [x] Code style clean (PHPCS PSR-12)