### PR TITLE
fix: remove @Depends chaining from ConnectionHandshakeTest, simplify tearDown

### DIFF
--- a/tests/E2E/ConnectionHandshakeTest.php
+++ b/tests/E2E/ConnectionHandshakeTest.php
@@ -17,7 +17,6 @@ use CrazyGoat\RabbitStream\Response\SaslAuthenticateResponseV1;
 use CrazyGoat\RabbitStream\Response\SaslHandshakeResponseV1;
 use CrazyGoat\RabbitStream\Response\TuneResponseV1;
 use CrazyGoat\RabbitStream\StreamConnection;
-use PHPUnit\Framework\Attributes\Depends;
 
 class ConnectionHandshakeTest extends E2ETestCase
 {
@@ -25,15 +24,7 @@ class ConnectionHandshakeTest extends E2ETestCase
 
     protected function tearDown(): void
     {
-        // Only close connection in tearDown for tests that don't provide it to dependents
-        // Provider tests (testPeerPropertiesExchange, testSaslHandshake) pass connection via return
-        $providerTests = ['testPeerPropertiesExchange', 'testSaslHandshake'];
-        $currentTest = $this->name();
-
-        $isProviderTest = in_array($currentTest, $providerTests, true);
-        $hasOpenConnection = $this->connection instanceof StreamConnection && $this->connection->isConnected();
-
-        if (!$isProviderTest && $hasOpenConnection) {
+        if ($this->connection instanceof StreamConnection && $this->connection->isConnected()) {
             $this->connection->close();
         }
         $this->connection = null;
@@ -44,44 +35,6 @@ class ConnectionHandshakeTest extends E2ETestCase
         $connection = new StreamConnection(self::$host, self::$port);
         $connection->connect();
         return $connection;
-    }
-
-    public function testPeerPropertiesExchange(): StreamConnection
-    {
-        $this->connection = $this->createRawConnection();
-
-        $this->connection->sendMessage(new PeerPropertiesRequestV1());
-        $response = $this->connection->readMessage();
-
-        $this->assertInstanceOf(PeerPropertiesResponseV1::class, $response);
-
-        return $this->connection;
-    }
-
-    #[Depends('testPeerPropertiesExchange')]
-    public function testSaslHandshake(StreamConnection $connection): StreamConnection
-    {
-        $this->connection = $connection;
-
-        $this->connection->sendMessage(new SaslHandshakeRequestV1());
-        $response = $this->connection->readMessage();
-
-        $this->assertInstanceOf(SaslHandshakeResponseV1::class, $response);
-
-        return $this->connection;
-    }
-
-    #[Depends('testSaslHandshake')]
-    public function testSaslAuthenticate(StreamConnection $connection): void
-    {
-        $this->connection = $connection;
-
-        $this->connection->sendMessage(new SaslAuthenticateRequestV1('PLAIN', 'guest', 'guest'));
-        $response = $this->connection->readMessage();
-
-        $this->assertInstanceOf(SaslAuthenticateResponseV1::class, $response);
-
-        $this->connection->close();
     }
 
     public function testFullHandshake(): void


### PR DESCRIPTION
Closes #357

## Summary

Removes the fragile @Depends chaining pattern from ConnectionHandshakeTest where three tests (testPeerPropertiesExchange, testSaslHandshake, testSaslAuthenticate) passed a StreamConnection instance between each other.

## Changes

- **Removed** testPeerPropertiesExchange, testSaslHandshake, testSaslAuthenticate — they used @Depends to chain tests, an anti-pattern in PHPUnit
- **Kept** testFullHandshake — already covers the full handshake flow end-to-end
- **Simplified** tearDown() — no longer inspects test name to decide cleanup; unconditionally closes the connection if open
- **Removed** unused PHPUnit\Framework\Attributes\Depends import

## Verification

- 628 unit tests pass
- PHP_CodeSniffer (PSR-12) passes
- Code review subagent — 0 findings