### PR TITLE
refactor: use ReadBuffer::readBytes consistently in OsirisChunkParser (closes #351)

### DIFF
--- a/src/Client/OsirisChunkParser.php
+++ b/src/Client/OsirisChunkParser.php
@@ -57,8 +57,7 @@ class OsirisChunkParser
 
             if (!$isSubBatch) {
                 $entrySize = $header & 0x7FFFFFFF;
-                $entryData = substr($chunkBytes, $buffer->getPosition(), $entrySize);
-                $buffer->skip($entrySize);
+                $entryData = $buffer->readBytes($entrySize);
                 $entries[] = new ChunkEntry($currentOffset, $entryData, $timestamp);
                 $currentOffset++;
             } else {
@@ -74,14 +73,12 @@ class OsirisChunkParser
 
                 $buffer->getUint32(); // uncompressedSize — read but not needed
                 $compressedSize = $buffer->getUint32();
-                $subBatchData = substr($chunkBytes, $buffer->getPosition(), $compressedSize);
-                $buffer->skip($compressedSize);
+                $subBatchData = $buffer->readBytes($compressedSize);
 
                 $subBuffer = new ReadBuffer($subBatchData);
                 for ($j = 0; $j < $uncompressedCount; $j++) {
                     $innerSize = $subBuffer->getUint32();
-                    $innerData = substr($subBatchData, $subBuffer->getPosition(), $innerSize);
-                    $subBuffer->skip($innerSize);
+                    $innerData = $subBuffer->readBytes($innerSize);
                     $entries[] = new ChunkEntry($currentOffset, $innerData, $timestamp);
                     $currentOffset++;
                 }


### PR DESCRIPTION
## Summary

Closes #351

Replaces raw `substr` + `skip()` calls with `ReadBuffer::readBytes()` in `OsirisChunkParser::parse()`:

- `$entryData = substr($chunkBytes, $buffer->getPosition(), $entrySize); $buffer->skip($entrySize)` → `$buffer->readBytes($entrySize)`
- `$subBatchData = substr($chunkBytes, $buffer->getPosition(), $compressedSize); $buffer->skip($compressedSize)` → `$buffer->readBytes($compressedSize)`
- `$innerData = substr($subBatchData, $subBuffer->getPosition(), $innerSize); $subBuffer->skip($innerSize)` → `$subBuffer->readBytes($innerSize)`

Line 49 already used `$buffer->readBytes(3)` — this change makes the code consistent.

## Changes

- `src/Client/OsirisChunkParser.php` — 3 replacements of `substr`+`skip` with `readBytes`

## Reference implementations checked

- [N/A] Go client: rabbitmq/rabbitmq-stream-go-client
- [N/A] Java client: rabbitmq/rabbitmq-stream-java-client
- [N/A] Rust client: rabbitmq/rabbitmq-stream-rust-client
- [N/A] Python client: qweeze/rstream
- [N/A] Protocol spec: PROTOCOL.adoc
- [N/A] AMQP 1.0 spec

## Testing

- Unit tests: pass (628 tests, 1362 assertions)
- Lint (PHPCS): pass
- PHPStan: pre-existing OOM issue (128M limit), not related to this change